### PR TITLE
[WIP] Feature:  Videx-For-Postgresql

### DIFF
--- a/src/pg/videx/Makefile
+++ b/src/pg/videx/Makefile
@@ -1,0 +1,27 @@
+# contrib/videx/Makefile
+
+MODULE_big = videx
+OBJS = \
+	$(WIN32RES) \
+	stats.o \
+	videxam.o \
+
+EXTENSION = videx
+DATA = videx--1.0.sql
+PGFILEDESC = "videx - virtual index extension for PostgreSQL"
+
+REGRESS_OPTS = --temp-config $(top_srcdir)/contrib/videx/videx.conf
+REGRESS = videx 
+
+TAP_TESTS = 1
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = contrib/videx 
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/src/pg/videx/README.md
+++ b/src/pg/videx/README.md
@@ -1,0 +1,26 @@
+### Videx For Postgresql
+
+Videx-for-pg is developing in the form of a PostgreSQL plugin...
+
+### Qucik Start
+##### step1: compile videx
+1. Copy the pg/videx folder to the contrib folder in your pg directory (such as postgresql17.5)
+2. go into postgresql17.5/contirb/videx: 
+`make && make install`
+
+##### step2：register videx in pg
+1. go to postgresql.conf:
+`shared_preload_libraries = 'videx'		# (change requires restart)`
+2. start your pg service and psql:
+`create extension videx;`
+
+#### step3: use videx
+1. create videx table using videx storage
+`CREATE TABLE V_REGION (
+	R_REGIONKEY	SERIAL,
+	R_NAME		CHAR(25),
+	R_COMMENT	VARCHAR(152)
+) USING VIDEX;`
+2. use function videx_analyze to copy statistics
+`SELECT videx_analyze('REGION'::regclass, 'V_REGION'::regclass)"`
+3. explain sql

--- a/src/pg/videx/stats.c
+++ b/src/pg/videx/stats.c
@@ -1,0 +1,309 @@
+#include "postgres.h"
+#include "fmgr.h"
+#include "utils/fmgroids.h"
+#include "access/htup_details.h"
+#include "catalog/pg_statistic.h"
+#include "catalog/pg_class.h"
+#include "catalog/pg_namespace.h"
+#include "utils/rel.h"
+#include "utils/syscache.h"
+#include "utils/lsyscache.h"
+#include "utils/builtins.h"
+#include "catalog/indexing.h"
+#include "access/table.h"
+#include "access/tableam.h"
+#include "utils/relcache.h"
+#include "utils/inval.h"
+#include "access/multixact.h"
+#include "commands/vacuum.h"
+#include "videxam.h"
+#include "access/heapam.h"
+#include "catalog/pg_index.h"
+#include "catalog/pg_statistic_ext.h"
+
+PG_MODULE_MAGIC;
+PG_FUNCTION_INFO_V1(videx_analyze);
+PG_FUNCTION_INFO_V1(videx_tableam_handler);
+
+static void
+copy_pg_statistic(Oid src_relid, Oid dst_relid)
+{
+    Relation stat_rel;
+    ScanKeyData key;
+    SysScanDesc scan;
+    HeapTuple tup;
+    CatalogIndexState indstate;
+    HeapTuple oldtup;
+
+    Datum values[Natts_pg_statistic];
+    bool nulls[Natts_pg_statistic];
+    bool replaces[Natts_pg_statistic];
+
+    stat_rel = table_open(StatisticRelationId, RowExclusiveLock);
+    if (!RelationIsValid(stat_rel))
+        elog(ERROR, "failed to open pg_statistic");
+    
+
+    ScanKeyInit(&key,
+                Anum_pg_statistic_starelid,
+                BTEqualStrategyNumber,
+                F_OIDEQ,
+                ObjectIdGetDatum(src_relid));
+
+    scan = systable_beginscan(stat_rel,
+                               StatisticRelidAttnumInhIndexId,
+                               true, NULL, 1, &key);
+
+    indstate = CatalogOpenIndexes(stat_rel);
+
+    while ((tup = systable_getnext(scan)) != NULL)
+    {
+        Form_pg_statistic stat_form = (Form_pg_statistic) GETSTRUCT(tup);
+
+        char *colname = get_attname(src_relid, stat_form->staattnum, false);
+        AttrNumber dst_attnum = get_attnum(dst_relid, colname);
+
+        if (dst_attnum == InvalidAttrNumber)
+            ereport(ERROR,
+                    (errmsg("target table does not contain column \"%s\"", colname)));
+
+
+        memset(values, 0, sizeof(values));
+        memset(nulls, false, sizeof(nulls));
+        memset(replaces, true, sizeof(replaces));
+
+        heap_deform_tuple(tup, RelationGetDescr(stat_rel), values, nulls);
+
+        values[Anum_pg_statistic_starelid - 1] = ObjectIdGetDatum(dst_relid);
+        values[Anum_pg_statistic_staattnum - 1] = Int16GetDatum(dst_attnum);
+
+        oldtup = SearchSysCache3(STATRELATTINH,
+                                           ObjectIdGetDatum(dst_relid),
+                                           Int16GetDatum(dst_attnum),
+                                           BoolGetDatum(stat_form->stainherit));
+
+        if (HeapTupleIsValid(oldtup))
+        {
+            HeapTuple newtup = heap_modify_tuple(oldtup,
+                                                 RelationGetDescr(stat_rel),
+                                                 values, nulls, replaces);
+            ReleaseSysCache(oldtup);
+            CatalogTupleUpdateWithInfo(stat_rel, &newtup->t_self, newtup, indstate);
+            heap_freetuple(newtup);
+        }
+        else
+        {
+            HeapTuple newtup = heap_form_tuple(RelationGetDescr(stat_rel), values, nulls);
+            CatalogTupleInsertWithInfo(stat_rel, newtup, indstate);
+            heap_freetuple(newtup);
+        }
+    }
+
+    CatalogCloseIndexes(indstate);
+    systable_endscan(scan);
+    table_close(stat_rel, RowExclusiveLock);
+}
+
+static void
+copy_pg_statistic_ext(Oid src_relid, Oid dst_relid)
+{
+    Relation stat_ext_rel;
+    ScanKeyData key;
+    SysScanDesc scan;
+    HeapTuple tup;
+    HeapTuple newtup;
+    CatalogIndexState indstate;
+
+    stat_ext_rel = table_open(StatisticExtRelationId, RowExclusiveLock);
+    if (!RelationIsValid(stat_ext_rel))
+        elog(ERROR, "failed to open pg_statistic_ext");
+
+    ScanKeyInit(&key,
+                 Anum_pg_statistic_ext_stxrelid,
+                 BTEqualStrategyNumber,
+                 F_OIDEQ,
+                 ObjectIdGetDatum(dst_relid));
+    scan = systable_beginscan(stat_ext_rel,
+                               StatisticExtRelidIndexId,
+                               true, NULL, 1, &key);
+
+    indstate = CatalogOpenIndexes(stat_ext_rel);
+
+    while ((tup = systable_getnext(scan)) != NULL)
+    {
+        CatalogTupleDelete(stat_ext_rel, &tup->t_self);
+    }
+    systable_endscan(scan);
+    
+    ScanKeyInit(&key,
+                 Anum_pg_statistic_ext_stxrelid,
+                 BTEqualStrategyNumber,
+                 F_OIDEQ,
+                 ObjectIdGetDatum(src_relid));
+
+    scan = systable_beginscan(stat_ext_rel,
+                            StatisticExtRelidIndexId,
+                               true, NULL, 1, &key);
+
+    while ((tup = systable_getnext(scan)) != NULL)
+    {
+        Datum values[Natts_pg_statistic_ext];
+        bool nulls[Natts_pg_statistic_ext];
+        Oid new_oid;
+        Oid namespace_oid;
+        char *new_stxname;
+
+        heap_deform_tuple(tup, RelationGetDescr(stat_ext_rel), values, nulls);
+
+        values[Anum_pg_statistic_ext_stxrelid - 1] = ObjectIdGetDatum(dst_relid);
+        
+        new_oid = GetNewOidWithIndex(stat_ext_rel, StatisticExtOidIndexId, Anum_pg_statistic_ext_oid);
+        values[Anum_pg_statistic_ext_oid - 1] = ObjectIdGetDatum(new_oid);
+
+        namespace_oid = get_rel_namespace(dst_relid);
+        values[Anum_pg_statistic_ext_stxnamespace - 1] = ObjectIdGetDatum(namespace_oid);
+
+        new_stxname = psprintf("viedex_%s", DatumGetCString(values[Anum_pg_statistic_ext_stxname - 1]));
+        values[Anum_pg_statistic_ext_stxname - 1] = new_stxname;
+
+        newtup = heap_form_tuple(RelationGetDescr(stat_ext_rel), values, nulls);
+        CatalogTupleInsertWithInfo(stat_ext_rel, newtup, indstate);
+        
+        heap_freetuple(newtup);
+    }
+
+    CatalogCloseIndexes(indstate);
+    systable_endscan(scan);
+    table_close(stat_ext_rel, RowExclusiveLock);
+}
+
+static void
+copy_pg_class_stats(Oid src_relid, Oid dst_relid)
+{
+    HeapTuple src_tup;
+    HeapTuple dst_tup;
+    Form_pg_class src_form;
+    Relation dst_rel;
+
+    src_tup = SearchSysCache1(RELOID, ObjectIdGetDatum(src_relid));
+    dst_tup = SearchSysCache1(RELOID, ObjectIdGetDatum(dst_relid));
+
+    if (!HeapTupleIsValid(src_tup) || !HeapTupleIsValid(dst_tup))
+        elog(ERROR, "pg_class tuple not found");
+
+    src_form = (Form_pg_class) GETSTRUCT(src_tup);
+
+    dst_rel = table_open(dst_relid, AccessShareLock);
+    
+    vac_update_relstats(dst_rel,
+                        src_form->relpages,
+                        src_form->reltuples,
+                        src_form->relallvisible,
+                        src_form->relhasindex,
+                        InvalidTransactionId,
+                        InvalidMultiXactId, 
+                        NULL,  
+                        NULL,  
+                        false 
+    );
+
+    table_close(dst_rel, AccessShareLock);
+
+    ReleaseSysCache(src_tup);
+    ReleaseSysCache(dst_tup);
+}
+
+Datum
+videx_analyze(PG_FUNCTION_ARGS)
+{
+    Oid src_relid = PG_GETARG_OID(0);
+    Oid dst_relid = PG_GETARG_OID(1);
+
+    elog(INFO, "Copying statistic from %u to %u", src_relid, dst_relid);
+    copy_pg_class_stats(src_relid, dst_relid);
+    copy_pg_statistic(src_relid, dst_relid);
+    copy_pg_statistic_ext(src_relid, dst_relid);
+
+    CommandCounterIncrement();
+    CacheInvalidateRelcacheByRelid(dst_relid);
+    PG_RETURN_VOID();
+}
+
+static const TableAmRoutine videxam_methods = {
+	.type = T_TableAmRoutine,
+
+    .slot_callbacks = videx_slot_callbacks,
+    .relation_estimate_size = videx_relation_estimate_size,
+    .relation_size = videx_relation_size,
+
+    .scan_begin = videx_scan_begin,
+    .scan_end = videx_scan_end,
+    .scan_rescan = videx_scan_rescan,
+
+    .scan_getnextslot = videx_getnextslot,
+    .relation_set_new_filelocator = videx_relation_set_new_filelocator,
+
+    .relation_needs_toast_table = videx_relation_needs_toast_table,
+    .relation_toast_am = videx_relation_toast_am,
+
+    /*for primary key and index*/
+    .index_build_range_scan = videx_index_build_range_scan,
+    .index_validate_scan = videx_index_validate_scan,
+    .scan_analyze_next_block = videx_scan_analyze_next_block,
+    .scan_analyze_next_tuple = videx_scan_analyze_next_tuple,
+
+    .parallelscan_estimate = table_block_parallelscan_estimate,
+    .parallelscan_initialize = table_block_parallelscan_initialize,
+    .parallelscan_reinitialize = table_block_parallelscan_reinitialize,
+
+    .index_fetch_begin = videx_index_fetch_begin,
+    .index_fetch_reset = videx_index_fetch_reset,
+    .index_fetch_end = videx_index_fetch_end,
+    .index_fetch_tuple = videx_index_fetch_tuple,
+};
+
+Datum
+videx_tableam_handler(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_POINTER(&videxam_methods);
+}
+
+// static get_relation_stats_hook_type prev_get_relation_stats_hook = NULL;
+// static get_index_stats_hook_type  prev_get_index_stats_hook = NULL;
+
+
+// static bool videx_get_relation_stats(PlannerInfo *root,
+//                                               RangeTblEntry *rte,
+//                                               AttrNumber attnum,
+//                                               VariableStatData *vardata);
+// static bool videx_get_index_stats(PlannerInfo *root,
+//                                            Oid indexOid,
+//                                            AttrNumber indexattnum,
+//                                            VariableStatData *vardata);
+
+
+/*
+ * Module load callback
+ */
+// void
+// _PG_init(void)
+// {
+//     /*Install hooks*/
+//     // prev_get_relation_stats_hook = get_relation_stats_hook;
+//     // get_relation_stats_hook = videx_get_relation_stats;
+//     // prev_get_index_stats_hook = get_index_stats_hook;
+//     // get_index_stats_hook = videx_get_index_stats;
+// }
+
+// static bool videx_get_relation_stats(PlannerInfo *root,
+//                                               RangeTblEntry *rte,
+//                                               AttrNumber attnum,
+//                                               VariableStatData *vardata){
+    
+// }
+
+// static bool videx_get_index_stats(PlannerInfo *root,
+//                                            Oid indexOid,
+//                                            AttrNumber indexattnum,
+//                                            VariableStatData *vardata){
+// }

--- a/src/pg/videx/videx--1.0.sql
+++ b/src/pg/videx/videx--1.0.sql
@@ -1,0 +1,10 @@
+CREATE FUNCTION videx_analyze(source regclass, target regclass)
+RETURNS void
+AS 'videx', 'videx_analyze'
+LANGUAGE C STRICT;
+
+CREATE OR REPLACE FUNCTION videx_tableam_handler(internal)
+RETURNS table_am_handler AS 'videx', 'videx_tableam_handler'
+LANGUAGE C STRICT;
+
+CREATE ACCESS METHOD videx TYPE TABLE HANDLER videx_tableam_handler;

--- a/src/pg/videx/videx.conf
+++ b/src/pg/videx/videx.conf
@@ -1,0 +1,1 @@
+shared_preload_libraries = 'videx'

--- a/src/pg/videx/videx.control
+++ b/src/pg/videx/videx.control
@@ -1,0 +1,5 @@
+# videx extension
+comment = 'videx'
+default_version = '1.0'
+module_pathname = '$libdir/videx'
+relocatable = true

--- a/src/pg/videx/videxam.c
+++ b/src/pg/videx/videxam.c
@@ -1,0 +1,268 @@
+#include "postgres.h"
+#include "access/bufmask.h"
+#include "access/heapam_xlog.h"
+#include "access/heaptoast.h"
+#include "access/hio.h"
+#include "access/multixact.h"
+#include "access/parallel.h"
+#include "access/relscan.h"
+#include "access/subtrans.h"
+#include "access/syncscan.h"
+#include "access/sysattr.h"
+#include "access/tableam.h"
+#include "access/transam.h"
+#include "access/valid.h"
+#include "access/visibilitymap.h"
+#include "access/xact.h"
+#include "access/xlog.h"
+#include "access/xloginsert.h"
+#include "access/xlogutils.h"
+#include "catalog/catalog.h"
+#include "catalog/pg_database.h"
+#include "catalog/pg_database_d.h"
+#include "commands/vacuum.h"
+#include "miscadmin.h"
+#include "pgstat.h"
+#include "port/atomics.h"
+#include "port/pg_bitutils.h"
+#include "storage/bufmgr.h"
+#include "storage/freespace.h"
+#include "storage/lmgr.h"
+#include "storage/predicate.h"
+#include "storage/procarray.h"
+#include "storage/standby.h"
+#include "utils/datum.h"
+#include "utils/injection_point.h"
+#include "utils/inval.h"
+#include "utils/relcache.h"
+#include "utils/snapmgr.h"
+#include "utils/spccache.h"
+#include "utils/syscache.h"
+#include "optimizer/optimizer.h"
+#include "optimizer/plancat.h"
+#include "videxam.h"
+#include <math.h>
+
+#define HEAP_OVERHEAD_BYTES_PER_TUPLE \
+	(MAXALIGN(SizeofHeapTupleHeader) + sizeof(ItemIdData))
+#define HEAP_USABLE_BYTES_PER_PAGE \
+	(BLCKSZ - SizeOfPageHeaderData)
+
+static void
+videx_table_block_relation_estimate_size(Relation rel, int32 *attr_widths,
+								   BlockNumber *pages, double *tuples,
+								   double *allvisfrac,
+								   Size overhead_bytes_per_tuple,
+						   Size usable_bytes_per_page);
+
+const TupleTableSlotOps *videx_slot_callbacks(Relation rel){
+    return &TTSOpsVirtual;
+}
+
+void videx_relation_estimate_size(Relation rel, int32 *attr_widths, 
+        BlockNumber *pages, double *tuples, double *allvisfrac){
+    return videx_table_block_relation_estimate_size(rel, attr_widths, pages,
+									   tuples, allvisfrac,
+									   HEAP_OVERHEAD_BYTES_PER_TUPLE,
+									   HEAP_USABLE_BYTES_PER_PAGE);
+}
+uint64 videx_relation_size(Relation rel, ForkNumber forkNumber){
+    return 0;
+}
+TableScanDesc videx_scan_begin(Relation rel, Snapshot snapshot,
+     int nkeys, struct ScanKeyData *key, ParallelTableScanDesc pscan, uint32 flags){
+  struct VidexScanDesc* scan;
+  scan = (struct VidexScanDesc*)malloc(sizeof(struct VidexScanDesc));
+  scan->rs_base.rs_rd = rel;
+  scan->rs_base.rs_snapshot = snapshot;
+  scan->rs_base.rs_nkeys = nkeys;
+  scan->rs_base.rs_flags = flags;
+  scan->rs_base.rs_parallel = pscan;
+  scan->cursor = 0;
+  return (TableScanDesc)scan;       
+}
+void videx_scan_end (TableScanDesc scan){
+	free(scan);
+}
+void videx_scan_rescan (TableScanDesc scan, struct ScanKeyData *key, 
+    bool set_params, bool allow_strat, bool allow_sync, bool allow_pagemode){}
+
+bool videx_getnextslot (TableScanDesc scan, ScanDirection direction,
+     TupleTableSlot *slot){
+	// struct VidexScanDesc* vscan = NULL;
+	// vscan = (struct VidexScanDesc*) scan;
+  	ExecClearTuple(slot);
+	return false;
+}
+
+void
+videx_table_block_relation_estimate_size(Relation rel, int32 *attr_widths,
+								   BlockNumber *pages, double *tuples,
+								   double *allvisfrac,
+								   Size overhead_bytes_per_tuple,
+								   Size usable_bytes_per_page)
+{
+	BlockNumber curpages;
+	BlockNumber relpages;
+	double		reltuples;
+	BlockNumber relallvisible;
+	double		density;
+
+	/* skip videx_relation_size , let curpage equal to relpages directly */
+	curpages = (BlockNumber) rel->rd_rel->relpages;
+
+	/* coerce values in pg_class to more desirable types */
+	relpages = (BlockNumber) rel->rd_rel->relpages;
+	reltuples = (double) rel->rd_rel->reltuples;
+	relallvisible = (BlockNumber) rel->rd_rel->relallvisible;
+
+	/*
+	 * HACK: if the relation has never yet been vacuumed, use a minimum size
+	 * estimate of 10 pages.  The idea here is to avoid assuming a
+	 * newly-created table is really small, even if it currently is, because
+	 * that may not be true once some data gets loaded into it.  Once a vacuum
+	 * or analyze cycle has been done on it, it's more reasonable to believe
+	 * the size is somewhat stable.
+	 *
+	 * (Note that this is only an issue if the plan gets cached and used again
+	 * after the table has been filled.  What we're trying to avoid is using a
+	 * nestloop-type plan on a table that has grown substantially since the
+	 * plan was made.  Normally, autovacuum/autoanalyze will occur once enough
+	 * inserts have happened and cause cached-plan invalidation; but that
+	 * doesn't happen instantaneously, and it won't happen at all for cases
+	 * such as temporary tables.)
+	 *
+	 * We test "never vacuumed" by seeing whether reltuples < 0.
+	 *
+	 * If the table has inheritance children, we don't apply this heuristic.
+	 * Totally empty parent tables are quite common, so we should be willing
+	 * to believe that they are empty.
+	 */
+	if (curpages < 10 &&
+		reltuples < 0 &&
+		!rel->rd_rel->relhassubclass)
+		curpages = 10;
+
+	/* report estimated # pages */
+	*pages = curpages;
+	/* quick exit if rel is clearly empty */
+	if (curpages == 0)
+	{
+		*tuples = 0;
+		*allvisfrac = 0;
+		return;
+	}
+
+	/* estimate number of tuples from previous tuple density */
+	if (reltuples >= 0 && relpages > 0)
+		density = reltuples / (double) relpages;
+	else
+	{
+		/*
+		 * When we have no data because the relation was never yet vacuumed,
+		 * estimate tuple width from attribute datatypes.  We assume here that
+		 * the pages are completely full, which is OK for tables but is
+		 * probably an overestimate for indexes.  Fortunately
+		 * get_relation_info() can clamp the overestimate to the parent
+		 * table's size.
+		 *
+		 * Note: this code intentionally disregards alignment considerations,
+		 * because (a) that would be gilding the lily considering how crude
+		 * the estimate is, (b) it creates platform dependencies in the
+		 * default plans which are kind of a headache for regression testing,
+		 * and (c) different table AMs might use different padding schemes.
+		 */
+		int32		tuple_width;
+		int			fillfactor;
+
+		/*
+		 * Without reltuples/relpages, we also need to consider fillfactor.
+		 * The other branch considers it implicitly by calculating density
+		 * from actual relpages/reltuples statistics.
+		 */
+		fillfactor = RelationGetFillFactor(rel, HEAP_DEFAULT_FILLFACTOR);
+
+		tuple_width = get_rel_data_width(rel, attr_widths);
+		tuple_width += overhead_bytes_per_tuple;
+		/* note: integer division is intentional here */
+		density = (usable_bytes_per_page * fillfactor / 100) / tuple_width;
+		/* There's at least one row on the page, even with low fillfactor. */
+		density = clamp_row_est(density);
+	}
+	*tuples = rint(density * (double) curpages);
+
+	/*
+	 * We use relallvisible as-is, rather than scaling it up like we do for
+	 * the pages and tuples counts, on the theory that any pages added since
+	 * the last VACUUM are most likely not marked all-visible.  But costsize.c
+	 * wants it converted to a fraction.
+	 */
+	if (relallvisible == 0 || curpages <= 0)
+		*allvisfrac = 0;
+	else if ((double) relallvisible >= curpages)
+		*allvisfrac = 1;
+	else
+		*allvisfrac = (double) relallvisible / curpages;
+}
+
+void videx_relation_set_new_filelocator (Relation rel,
+												 const RelFileLocator *newrlocator,
+												 char persistence,
+												 TransactionId *freezeXid,
+												 MultiXactId *minmulti){			
+	return;									
+}
+
+bool videx_relation_needs_toast_table(Relation rel){
+	return false;
+}
+
+Oid videx_relation_toast_am(Relation rel){
+  Oid oid = 0;
+  return oid;
+}
+double videx_index_build_range_scan(Relation table_rel, Relation index_rel, 
+     struct IndexInfo *index_info, bool allow_sync, bool anyvisible, bool progress, 
+     BlockNumber start_blockno, BlockNumber numblocks, IndexBuildCallback callback, 
+     void *callback_state, TableScanDesc scan){
+	return 0;
+}
+void videx_index_validate_scan(Relation table_rel, Relation index_rel, 
+     struct IndexInfo *index_info, Snapshot snapshot, struct ValidateIndexState *state){
+	return;
+}
+
+bool videx_scan_analyze_next_block(TableScanDesc scan, ReadStream *stream){
+	return false;
+}
+
+bool videx_scan_analyze_next_tuple(TableScanDesc scan, TransactionId OldestXmin, 
+     double *liverows, double *deadrows, TupleTableSlot *slot){
+	return false;
+}
+
+// Size videx_parallelscan_estimate(Relation rel){
+
+// }
+
+// Size videx_parallelscan_initialize(Relation rel, ParallelTableScanDesc pscan){
+
+// }
+
+// void videx_parallelscan_reinitialize(Relation rel, ParallelTableScanDesc pscan){
+
+// }
+
+struct IndexFetchTableData* videx_index_fetch_begin(Relation rel){
+	return NULL;
+}
+void videx_index_fetch_reset(struct IndexFetchTableData *data){
+	
+}
+void videx_index_fetch_end(struct IndexFetchTableData *data){
+
+}
+bool videx_index_fetch_tuple(struct IndexFetchTableData *scan, ItemPointer tid, 
+     Snapshot snapshot, TupleTableSlot *slot, bool *call_again, bool *all_dead){
+	return false;
+}

--- a/src/pg/videx/videxam.h
+++ b/src/pg/videx/videxam.h
@@ -1,0 +1,63 @@
+#ifndef VIDEXAM_H
+#define VIDEXAM_H
+
+#include "access/relation.h"	/* for backward compatibility */
+#include "access/relscan.h"
+#include "access/sdir.h"
+#include "access/skey.h"
+#include "access/table.h"		/* for backward compatibility */
+#include "access/tableam.h"
+#include "nodes/lockoptions.h"
+#include "nodes/primnodes.h"
+#include "storage/bufpage.h"
+#include "storage/dsm.h"
+#include "storage/lockdefs.h"
+#include "storage/read_stream.h"
+#include "storage/shm_toc.h"
+#include "utils/relcache.h"
+#include "utils/snapshot.h"
+
+
+struct VidexScanDesc {
+  /*Base class from access/relscan.h.*/
+  TableScanDescData rs_base;
+  uint32 cursor;
+};
+
+
+extern const TupleTableSlotOps* videx_slot_callbacks(Relation rel);
+extern void videx_relation_estimate_size(Relation rel, int32 *attr_widths, 
+        BlockNumber *pages, double *tuples, double *allvisfrac);
+extern uint64 videx_relation_size(Relation rel, ForkNumber forkNumber);
+extern TableScanDesc videx_scan_begin(Relation rel, Snapshot snapshot,
+     int nkeys, struct ScanKeyData *key, ParallelTableScanDesc pscan, uint32 flags);
+extern void videx_scan_end (TableScanDesc scan);
+extern void videx_scan_rescan (TableScanDesc scan, struct ScanKeyData *key, 
+    bool set_params, bool allow_strat, bool allow_sync, bool allow_pagemode);
+extern bool videx_getnextslot (TableScanDesc scan, ScanDirection direction,
+     TupleTableSlot *slot);
+extern void videx_relation_set_new_filelocator (Relation rel,
+												 const RelFileLocator *newrlocator,
+												 char persistence,
+												 TransactionId *freezeXid,
+												 MultiXactId *minmulti);
+extern bool videx_relation_needs_toast_table(Relation rel);
+extern Oid videx_relation_toast_am(Relation rel);
+extern double videx_index_build_range_scan(Relation table_rel, Relation index_rel, 
+     struct IndexInfo *index_info, bool allow_sync, bool anyvisible, bool progress, 
+     BlockNumber start_blockno, BlockNumber numblocks, IndexBuildCallback callback, 
+     void *callback_state, TableScanDesc scan);
+extern void videx_index_validate_scan(Relation table_rel, Relation index_rel, 
+     struct IndexInfo *index_info, Snapshot snapshot, struct ValidateIndexState *state);
+extern bool videx_scan_analyze_next_block(TableScanDesc scan, ReadStream *stream);
+extern bool videx_scan_analyze_next_tuple(TableScanDesc scan, TransactionId OldestXmin, 
+     double *liverows, double *deadrows, TupleTableSlot *slot);
+// extern Size videx_parallelscan_estimate(Relation rel);
+// extern Size videx_parallelscan_initialize(Relation rel, ParallelTableScanDesc pscan);
+// extern void videx_parallelscan_reinitialize(Relation rel, ParallelTableScanDesc pscan);
+extern struct IndexFetchTableData* videx_index_fetch_begin(Relation rel);
+extern void videx_index_fetch_reset(struct IndexFetchTableData *data);
+extern void videx_index_fetch_end(struct IndexFetchTableData *data);
+extern bool videx_index_fetch_tuple(struct IndexFetchTableData *scan, ItemPointer tid, 
+     Snapshot snapshot, TupleTableSlot *slot, bool *call_again, bool *all_dead);
+#endif							/* VIDEXAM_H */


### PR DESCRIPTION
### Videx For Postgresql

1. Videx-for-pg is developing in the form of a PostgreSQL plugin.
2. Currently, only copying of local statistical information is supported

### Qucik Start
##### Step1: compile videx
1. Copy the pg/videx folder to the contrib folder in your pg directory (such as postgresql17.5)
3. Go into postgresql17.5/contirb/videx: 
```sql
make && make install
```

##### Step2：register videx in pg
1. Modify postgresql.conf:
```sql 
shared_preload_libraries = 'videx'		# (change requires restart)
```
2. Start your pg service and psql:
```sql
create extension videx;
```

#### Step3: use videx
1. Create videx table using videx storage
```sql
CREATE TABLE V_REGION (
    R_REGIONKEY    SERIAL,
    R_NAME         CHAR(25),
    R_COMMENT      VARCHAR(152)
) USING VIDEX;
```
2. Use self-function videx_analyze to copy statistics
```sql
SELECT videx_analyze('REGION'::regclass, 'V_REGION'::regclass)"
```
4. Manually create same index like srouce table 
5. explain sqls
