### PR TITLE
Fix template linking error for gcc

### DIFF
--- a/src/mariadb/videx/videx_utils.cc
+++ b/src/mariadb/videx/videx_utils.cc
@@ -208,14 +208,6 @@ void VidexJsonItem::add_property(const std::string &key, const String *value)
   }
 }
 
-template <typename V>
-void VidexJsonItem::add_property_nonan(const std::string &key, V value)
-{
-  std::stringstream ss;
-  ss << value;
-  properties[key]= ss.str();
-}
-
 std::string VidexJsonItem::to_json() const
 {
   std::string json= "{";

--- a/src/mariadb/videx/videx_utils.h
+++ b/src/mariadb/videx/videx_utils.h
@@ -110,7 +110,12 @@ public:
   // Except for string which might be empty and needs to be converted to NULL
   // separately, all other values can be handled using this function.
   template <typename V>
-  void add_property_nonan(const std::string &key, V value);
+  void add_property_nonan(const std::string &key, V value)
+  {
+    std::stringstream ss;
+    ss << value;
+    properties[key]= ss.str();
+  }
 
   std::string to_json() const;
 };


### PR DESCRIPTION
## Pull Request Summary

### Reason
Videx builds failed with undefined reference errors:

```bash
undefined reference to `void VidexJsonItem::add_property_nonan<unsigned int>(...)`
```

This occurred when compiling with gcc, even though it worked with clang 19.

### Solution

Moved the template method definition from videx_utils.cc to videx_utils.h

In gcc environment, we have the following cmake.

```bash
/usr/bin/cmake -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_C_COMPILER=/usr/bin/gcc \
  -DCMAKE_CXX_COMPILER=/usr/bin/g++ \
  -G Ninja --fresh \
  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
  -DCMAKE_C_COMPILER_LAUNCHER=ccache \
  -DCMAKE_INSTALL_PREFIX=/root/mariadb_server/mysql_build_output \
  -DMYSQL_DATADIR=/root/mariadb_server/mysql_build_output/data \
  -DSYSCONFDIR=/root/mariadb_server/mysql_build_output/etc \
  -DPLUGIN_COLUMNSTORE=NO \
  -DPLUGIN_ROCKSDB=NO \
  -DPLUGIN_S3=NO \
  -DPLUGIN_MROONGA=NO \
  -DPLUGIN_CONNECT=NO \
  -DPLUGIN_TOKUDB=NO \
  -DPLUGIN_PERFSCHEMA=NO \
  -DWITH_WSREP=OFF \
  -DPLUGIN_VIDEX=YES \
  -S /root/mariadb_server \
  -B /root/mariadb_server/mysql_build_output/build
```

The log below shows that the current codebase works well for g++ (Debian 15.2.0-4) 15.2.0.

```bash
# /usr/bin/cmake -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_C_COMPILER=/usr/bin/gcc \
  -DCMAKE_CXX_COMPILER=/usr/bin/g++ \
  -G Ninja --fresh \
  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
  -DCMAKE_C_COMPILER_LAUNCHER=ccache \
  -DCMAKE_INSTALL_PREFIX=/root/mariadb_server/mysql_build_output \
  -DMYSQL_DATADIR=/root/mariadb_server/mysql_build_output/data \
  -DSYSCONFDIR=/root/mariadb_server/mysql_build_output/etc \
  -DPLUGIN_COLUMNSTORE=NO \
  -DPLUGIN_ROCKSDB=NO \
  -DPLUGIN_S3=NO \
  -DPLUGIN_MROONGA=NO \
  -DPLUGIN_CONNECT=NO \
  -DPLUGIN_TOKUDB=NO \
  -DPLUGIN_PERFSCHEMA=NO \
  -DWITH_WSREP=OFF \
  -DPLUGIN_VIDEX=YES \
  -S /root/mariadb_server \
  -B /root/mariadb_server/mysql_build_output/build> > > > > > > > > > > > > > > > > > > 
-- The C compiler identification is GNU 15.2.0
-- The CXX compiler identification is GNU 15.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Running cmake version 3.31.6
-- Found Git: /usr/bin/git (found version "2.51.0")
-- MariaDB 11.8.4
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of void *
-- Check size of void * - done
-- Packaging as: mariadb-11.8.4-Linux-aarch64
-- Updating submodules
-- Performing Test HAVE_VISIBILITY_HIDDEN
-- Performing Test HAVE_VISIBILITY_HIDDEN - Success
-- Performing Test have_C__fno_omit_frame_pointer
-- Performing Test have_C__fno_omit_frame_pointer - Success
-- Performing Test have_CXX__fno_omit_frame_pointer
-- Performing Test have_CXX__fno_omit_frame_pointer - Success
-- Performing Test have_C__pie__fPIC
-- Performing Test have_C__pie__fPIC - Success
-- Performing Test have_CXX__pie__fPIC
-- Performing Test have_CXX__pie__fPIC - Success
-- Performing Test HAVE_LINK_FLAG__Wl__z_relro__z_now
-- Performing Test HAVE_LINK_FLAG__Wl__z_relro__z_now - Success
-- Performing Test have_C__fstack_protector___param_ssp_buffer_size_4
-- Performing Test have_C__fstack_protector___param_ssp_buffer_size_4 - Success
-- Performing Test have_CXX__fstack_protector___param_ssp_buffer_size_4
-- Performing Test have_CXX__fstack_protector___param_ssp_buffer_size_4 - Success
-- Performing Test have_C__D_FORTIFY_SOURCE_2
-- Performing Test have_C__D_FORTIFY_SOURCE_2 - Success
-- Performing Test have_CXX__D_FORTIFY_SOURCE_2
-- Performing Test have_CXX__D_FORTIFY_SOURCE_2 - Success
-- Performing Test have_C__ggdb3
-- Performing Test have_C__ggdb3 - Success
-- Performing Test have_CXX__ggdb3
-- Performing Test have_CXX__ggdb3 - Success
-- Performing Test have_C__moutline_atomics
-- Performing Test have_C__moutline_atomics - Success
-- Performing Test have_CXX__moutline_atomics
-- Performing Test have_CXX__moutline_atomics - Success
-- Looking for floor
-- Looking for floor - not found
-- Looking for floor in m
-- Looking for floor in m - found
-- Looking for gethostbyname_r
-- Looking for gethostbyname_r - found
-- Looking for bind
-- Looking for bind - found
-- Looking for crypt
-- Looking for crypt - not found
-- Looking for crypt in crypt
-- Looking for crypt in crypt - found
-- Looking for setsockopt
-- Looking for setsockopt - found
-- Looking for sched_yield
-- Looking for sched_yield - found
-- Looking for clock_gettime
-- Looking for clock_gettime - found
-- Looking for backtrace_symbols_fd
-- Looking for backtrace_symbols_fd - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Looking for 4 include files stdlib.h, ..., float.h
-- Looking for 4 include files stdlib.h, ..., float.h - found
-- Looking for include file alloca.h
-- Looking for include file alloca.h - found
-- Looking for include file arpa/inet.h
-- Looking for include file arpa/inet.h - found
-- Looking for include file crypt.h
-- Looking for include file crypt.h - found
-- Looking for include file dirent.h
-- Looking for include file dirent.h - found
-- Looking for include file dlfcn.h
-- Looking for include file dlfcn.h - found
-- Looking for include file execinfo.h
-- Looking for include file execinfo.h - found
-- Looking for include file fcntl.h
-- Looking for include file fcntl.h - found
-- Looking for include file fenv.h
-- Looking for include file fenv.h - found
-- Looking for include file float.h
-- Looking for include file float.h - found
-- Looking for include file fpu_control.h
-- Looking for include file fpu_control.h - found
-- Looking for include file grp.h
-- Looking for include file grp.h - found
-- Looking for include file ieeefp.h
-- Looking for include file ieeefp.h - not found
-- Looking for include file inttypes.h
-- Looking for include file inttypes.h - found
-- Looking for include file immintrin.h
-- Looking for include file immintrin.h - not found
-- Looking for include file langinfo.h
-- Looking for include file langinfo.h - found
-- Looking for include file link.h
-- Looking for include file link.h - found
-- Looking for include file linux/unistd.h
-- Looking for include file linux/unistd.h - found
-- Looking for include file limits.h
-- Looking for include file limits.h - found
-- Looking for include file locale.h
-- Looking for include file locale.h - found
-- Looking for include file malloc.h
-- Looking for include file malloc.h - found
-- Looking for include file memory.h
-- Looking for include file memory.h - found
-- Looking for include file ndir.h
-- Looking for include file ndir.h - not found
-- Looking for include file netinet/in.h
-- Looking for include file netinet/in.h - found
-- Looking for include file paths.h
-- Looking for include file paths.h - found
-- Looking for include file poll.h
-- Looking for include file poll.h - found
-- Looking for include file sys/poll.h
-- Looking for include file sys/poll.h - found
-- Looking for include file pwd.h
-- Looking for include file pwd.h - found
-- Looking for include file sched.h
-- Looking for include file sched.h - found
-- Looking for include file select.h
-- Looking for include file select.h - not found
-- Looking for include files sys/types.h, sys/dir.h
-- Looking for include files sys/types.h, sys/dir.h - found
-- Looking for include files sys/types.h, sys/event.h
-- Looking for include files sys/types.h, sys/event.h - not found
-- Looking for include file sys/ndir.h
-- Looking for include file sys/ndir.h - not found
-- Looking for include file sys/pte.h
-- Looking for include file sys/pte.h - not found
-- Looking for include file stdlib.h
-- Looking for include file stdlib.h - found
-- Looking for include file strings.h
-- Looking for include file strings.h - found
-- Looking for include file string.h
-- Looking for include file string.h - found
-- Looking for include file synch.h
-- Looking for include file synch.h - not found
-- Looking for include file sysent.h
-- Looking for include file sysent.h - not found
-- Looking for include file sys/file.h
-- Looking for include file sys/file.h - found
-- Looking for include file sys/fpu.h
-- Looking for include file sys/fpu.h - not found
-- Looking for include file sys/ioctl.h
-- Looking for include file sys/ioctl.h - found
-- Looking for include files sys/types.h, sys/malloc.h
-- Looking for include files sys/types.h, sys/malloc.h - not found
-- Looking for include file sys/mman.h
-- Looking for include file sys/mman.h - found
-- Looking for include file linux/mman.h
-- Looking for include file linux/mman.h - found
-- Looking for include file sys/prctl.h
-- Looking for include file sys/prctl.h - found
-- Looking for include file sys/resource.h
-- Looking for include file sys/resource.h - found
-- Looking for include file sys/select.h
-- Looking for include file sys/select.h - found
-- Looking for include file sys/socket.h
-- Looking for include file sys/socket.h - found
-- Looking for include file sys/stat.h
-- Looking for include file sys/stat.h - found
-- Looking for include file sys/stream.h
-- Looking for include file sys/stream.h - not found
-- Looking for include file sys/syscall.h
-- Looking for include file sys/syscall.h - found
-- Looking for include file asm/termbits.h
-- Looking for include file asm/termbits.h - found
-- Looking for include file termbits.h
-- Looking for include file termbits.h - not found
-- Looking for include file termios.h
-- Looking for include file termios.h - found
-- Looking for include file termio.h
-- Looking for include file termio.h - found
-- Looking for include file termcap.h
-- Looking for include file termcap.h - found
-- Looking for include file unistd.h
-- Looking for include file unistd.h - found
-- Looking for include file utime.h
-- Looking for include file utime.h - found
-- Looking for include file varargs.h
-- Looking for include file varargs.h - not found
-- Looking for include file sys/time.h
-- Looking for include file sys/time.h - found
-- Looking for include file sys/utime.h
-- Looking for include file sys/utime.h - not found
-- Looking for include file sys/wait.h
-- Looking for include file sys/wait.h - found
-- Looking for include file sys/param.h
-- Looking for include file sys/param.h - found
-- Looking for include file sys/vadvise.h
-- Looking for include file sys/vadvise.h - not found
-- Looking for include file fnmatch.h
-- Looking for include file fnmatch.h - found
-- Looking for include file stdarg.h
-- Looking for include file stdarg.h - found
-- Looking for include files stdlib.h, sys/un.h
-- Looking for include files stdlib.h, sys/un.h - found
-- Looking for include file wchar.h
-- Looking for include file wchar.h - found
-- Looking for include file wctype.h
-- Looking for include file wctype.h - found
-- Looking for include file sys/sockio.h
-- Looking for include file sys/sockio.h - not found
-- Looking for include file sys/utsname.h
-- Looking for include file sys/utsname.h - found
-- Looking for include file sys/statvfs.h
-- Looking for include file sys/statvfs.h - found
-- Looking for include file bfd.h
-- Looking for include file bfd.h - not found
-- Looking for include file sys/ptem.h
-- Looking for include file sys/ptem.h - not found
-- Performing Test have_C__Werror
-- Performing Test have_C__Werror - Success
-- Performing Test HAVE_PTHREAD_ONCE_INIT
-- Performing Test HAVE_PTHREAD_ONCE_INIT - Success
-- Looking for accept4
-- Looking for accept4 - found
-- Looking for access
-- Looking for access - found
-- Looking for backtrace
-- Looking for backtrace - found
-- Looking for backtrace_symbols
-- Looking for backtrace_symbols - found
-- Looking for backtrace_symbols_fd
-- Looking for backtrace_symbols_fd - found
-- Looking for printstack
-- Looking for printstack - not found
-- Looking for bfill
-- Looking for bfill - not found
-- Looking for index
-- Looking for index - found
-- Looking for clock_gettime
-- Looking for clock_gettime - found
-- Looking for cuserid
-- Looking for cuserid - found
-- Looking for ftruncate
-- Looking for ftruncate - found
-- Looking for compress
-- Looking for compress - not found
-- Looking for crypt
-- Looking for crypt - found
-- Looking for dladdr
-- Looking for dladdr - found
-- Looking for dlerror
-- Looking for dlerror - found
-- Looking for dlopen
-- Looking for dlopen - found
-- Looking for fchmod
-- Looking for fchmod - found
-- Looking for fcntl
-- Looking for fcntl - found
-- Looking for fdatasync
-- Looking for fdatasync - found
-- Looking for fdatasync
-- Looking for fdatasync - found
-- Looking for fesetround
-- Looking for fesetround - found
-- Looking for fedisableexcept
-- Looking for fedisableexcept - found
-- Looking for fseeko
-- Looking for fseeko - found
-- Looking for fsync
-- Looking for fsync - found
-- Looking for getcwd
-- Looking for getcwd - found
-- Looking for gethostbyaddr_r
-- Looking for gethostbyaddr_r - found
-- Looking for gethrtime
-- Looking for gethrtime - not found
-- Looking for getpass
-- Looking for getpass - found
-- Looking for getpassphrase
-- Looking for getpassphrase - not found
-- Looking for getpwnam
-- Looking for getpwnam - found
-- Looking for getpwuid
-- Looking for getpwuid - found
-- Looking for getrlimit
-- Looking for getrlimit - found
-- Looking for getifaddrs
-- Looking for getifaddrs - found
-- Looking for getrusage
-- Looking for getrusage - found
-- Looking for getwd
-- Looking for getwd - found
-- Looking for gmtime_r
-- Looking for gmtime_r - found
-- Looking for initgroups
-- Looking for initgroups - found
-- Looking for ldiv
-- Looking for ldiv - found
-- Looking for localtime_r
-- Looking for localtime_r - found
-- Looking for lstat
-- Looking for lstat - found
-- Looking for madvise
-- Looking for madvise - found
-- Looking for mallinfo
-- Looking for mallinfo - found
-- Looking for mallinfo2
-- Looking for mallinfo2 - found
-- Looking for malloc_zone_statistics
-- Looking for malloc_zone_statistics - not found
-- Looking for memcpy
-- Looking for memcpy - found
-- Looking for memmove
-- Looking for memmove - found
-- Looking for mkstemp
-- Looking for mkstemp - found
-- Looking for mkostemp
-- Looking for mkostemp - found
-- Looking for mlock
-- Looking for mlock - found
-- Looking for mlockall
-- Looking for mlockall - found
-- Looking for mmap
-- Looking for mmap - found
-- Looking for mmap64
-- Looking for mmap64 - found
-- Looking for mprotect
-- Looking for mprotect - found
-- Looking for perror
-- Looking for perror - found
-- Looking for poll
-- Looking for poll - found
-- Looking for posix_fallocate
-- Looking for posix_fallocate - found
-- Looking for pread
-- Looking for pread - found
-- Looking for pthread_attr_create
-- Looking for pthread_attr_create - not found
-- Looking for pthread_attr_getstacksize
-- Looking for pthread_attr_getstacksize - found
-- Looking for pthread_attr_setscope
-- Looking for pthread_attr_setscope - found
-- Looking for pthread_attr_getguardsize
-- Looking for pthread_attr_getguardsize - found
-- Looking for pthread_attr_setstacksize
-- Looking for pthread_attr_setstacksize - found
-- Looking for pthread_condattr_create
-- Looking for pthread_condattr_create - not found
-- Looking for pthread_getaffinity_np
-- Looking for pthread_getaffinity_np - found
-- Looking for pthread_getattr_np
-- Looking for pthread_getattr_np - found
-- Looking for pthread_rwlock_rdlock
-- Looking for pthread_rwlock_rdlock - found
-- Looking for pthread_sigmask
-- Looking for pthread_sigmask - found
-- Looking for pthread_yield_np
-- Looking for pthread_yield_np - not found
-- Looking for putenv
-- Looking for putenv - found
-- Looking for readlink
-- Looking for readlink - found
-- Looking for realpath
-- Looking for realpath - found
-- Looking for rename
-- Looking for rename - found
-- Looking for rwlock_init
-- Looking for rwlock_init - not found
-- Looking for sched_yield
-- Looking for sched_yield - found
-- Looking for setenv
-- Looking for setenv - found
-- Looking for setlocale
-- Looking for setlocale - found
-- Looking for sigaction
-- Looking for sigaction - found
-- Looking for sigthreadmask
-- Looking for sigthreadmask - not found
-- Looking for sigwait
-- Looking for sigwait - found
-- Looking for sigwaitinfo
-- Looking for sigwaitinfo - found
-- Looking for sigset
-- Looking for sigset - found
-- Looking for sleep
-- Looking for sleep - found
-- Looking for stpcpy
-- Looking for stpcpy - found
-- Looking for strcoll
-- Looking for strcoll - found
-- Looking for strerror
-- Looking for strerror - found
-- Looking for strnlen
-- Looking for strnlen - found
-- Looking for strpbrk
-- Looking for strpbrk - found
-- Looking for strtok_r
-- Looking for strtok_r - found
-- Looking for strtoll
-- Looking for strtoll - found
-- Looking for strtoul
-- Looking for strtoul - found
-- Looking for strtoull
-- Looking for strtoull - found
-- Looking for strcasecmp
-- Looking for strcasecmp - found
-- Looking for tell
-- Looking for tell - not found
-- Looking for thr_yield
-- Looking for thr_yield - not found
-- Looking for vasprintf
-- Looking for vasprintf - found
-- Looking for vsnprintf
-- Looking for vsnprintf - found
-- Looking for nl_langinfo
-- Looking for nl_langinfo - found
-- Performing Test HAVE_READDIR_R
-- Performing Test HAVE_READDIR_R - Failed
-- Looking for include file time.h
-- Looking for include file time.h - found
-- Looking for include file sys/times.h
-- Looking for include file sys/times.h - found
-- Looking for include file ia64intrin.h
-- Looking for include file ia64intrin.h - not found
-- Looking for times
-- Looking for times - found
-- Looking for gettimeofday
-- Looking for gettimeofday - found
-- Looking for read_real_time
-- Looking for read_real_time - not found
-- Looking for ftime
-- Looking for ftime - found
-- Looking for time
-- Looking for time - found
-- Looking for madvise
-- Looking for madvise - found
-- Looking for getpagesizes
-- Looking for getpagesizes - not found
-- Looking for tzname
-- Looking for tzname - found
-- Looking for lrand48
-- Looking for lrand48 - found
-- Looking for TIOCGWINSZ
-- Looking for TIOCGWINSZ - found
-- Looking for FIONREAD
-- Looking for FIONREAD - found
-- Looking for TIOCSTAT
-- Looking for TIOCSTAT - not found
-- Looking for FIONREAD
-- Looking for FIONREAD - not found
-- Check size of sigset_t
-- Check size of sigset_t - done
-- Check size of mode_t
-- Check size of mode_t - done
-- Check size of sighandler_t
-- Check size of sighandler_t - done
-- Check size of in_addr_t
-- Check size of in_addr_t - done
-- Check size of char *
-- Check size of char * - done
-- Check size of long
-- Check size of long - done
-- Check size of size_t
-- Check size of size_t - done
-- Check size of short
-- Check size of short - done
-- Check size of int
-- Check size of int - done
-- Check size of long long
-- Check size of long long - done
-- Check size of off_t
-- Check size of off_t - done
-- Check size of uchar
-- Check size of uchar - failed
-- Check size of uint
-- Check size of uint - done
-- Check size of ulong
-- Check size of ulong - done
-- Check size of int8
-- Check size of int8 - failed
-- Check size of uint8
-- Check size of uint8 - failed
-- Check size of int16
-- Check size of int16 - failed
-- Check size of uint16
-- Check size of uint16 - failed
-- Check size of int32
-- Check size of int32 - failed
-- Check size of uint32
-- Check size of uint32 - failed
-- Check size of int64
-- Check size of int64 - failed
-- Check size of uint64
-- Check size of uint64 - failed
-- Check size of time_t
-- Check size of time_t - done
-- Performing Test TIME_T_UNSIGNED
-- Performing Test TIME_T_UNSIGNED - Failed
-- Performing Test HAVE_SELECT
-- Performing Test HAVE_SELECT - Success
-- Performing Test HAVE_TIMESPEC_TS_SEC
-- Performing Test HAVE_TIMESPEC_TS_SEC - Failed
-- Performing Test QSORT_TYPE_IS_VOID
-- Performing Test QSORT_TYPE_IS_VOID - Success
-- Performing Test HAVE_SOCKET_SIZE_T_AS_socklen_t
-- Performing Test HAVE_SOCKET_SIZE_T_AS_socklen_t - Success
-- Performing Test HAVE_PTHREAD_YIELD_ZERO_ARG
-- Performing Test HAVE_PTHREAD_YIELD_ZERO_ARG - Success
-- Performing Test SIGNAL_RETURN_TYPE_IS_VOID
-- Performing Test SIGNAL_RETURN_TYPE_IS_VOID - Success
-- Looking for include files time.h, sys/time.h
-- Looking for include files time.h, sys/time.h - found
-- Looking for O_NONBLOCK
-- Looking for O_NONBLOCK - found
-- Performing Test C_HAS_inline
-- Performing Test C_HAS_inline - Success
-- Looking for tcgetattr
-- Looking for tcgetattr - found
-- Performing Test HAVE_POSIX_SIGNALS
-- Performing Test HAVE_POSIX_SIGNALS - Success
-- Performing Test HAVE_ABI_CXA_DEMANGLE
-- Performing Test HAVE_ABI_CXA_DEMANGLE - Success
-- Performing Test HAVE_WEAK_SYMBOL
-- Performing Test HAVE_WEAK_SYMBOL - Success
-- Performing Test HAVE_ATTRIBUTE_CLEANUP
-- Performing Test HAVE_ATTRIBUTE_CLEANUP - Success
-- Performing Test HAVE_CXX_NEW
-- Performing Test HAVE_CXX_NEW - Success
-- Performing Test HAVE_SOLARIS_STYLE_GETHOST
-- Performing Test HAVE_SOLARIS_STYLE_GETHOST - Failed
-- Performing Test HAVE_GCC_C11_ATOMICS_WITHOUT_LIBATOMIC
-- Performing Test HAVE_GCC_C11_ATOMICS_WITHOUT_LIBATOMIC - Success
-- Looking for include files valgrind/memcheck.h, valgrind/valgrind.h
-- Looking for include files valgrind/memcheck.h, valgrind/valgrind.h - not found
-- Looking for netinet/in6.h
-- Looking for netinet/in6.h - not found
-- Check size of struct sockaddr_in6
-- Check size of struct sockaddr_in6 - done
-- Check size of struct in6_addr
-- Check size of struct in6_addr - done
-- Performing Test HAVE_SOCKADDR_STORAGE_SS_FAMILY
-- Performing Test HAVE_SOCKADDR_STORAGE_SS_FAMILY - Success
-- Performing Test HAVE_SOCKADDR_IN_SIN_LEN
-- Performing Test HAVE_SOCKADDR_IN_SIN_LEN - Failed
-- Performing Test HAVE_SOCKADDR_IN6_SIN6_LEN
-- Performing Test HAVE_SOCKADDR_IN6_SIN6_LEN - Failed
-- Performing Test STRUCT_DIRENT_HAS_D_INO
-- Performing Test STRUCT_DIRENT_HAS_D_INO - Success
-- Performing Test STRUCT_DIRENT_HAS_D_NAMLEN
-- Performing Test STRUCT_DIRENT_HAS_D_NAMLEN - Failed
-- Performing Test STRUCT_TIMESPEC_HAS_TV_SEC
-- Performing Test STRUCT_TIMESPEC_HAS_TV_SEC - Success
-- Performing Test STRUCT_TIMESPEC_HAS_TV_NSEC
-- Performing Test STRUCT_TIMESPEC_HAS_TV_NSEC - Success
-- Performing Test STRUCT_TM_HAS_TM_GMTOFF
-- Performing Test STRUCT_TM_HAS_TM_GMTOFF - Success
-- Performing Test HAVE_FALLOC_PUNCH_HOLE_AND_KEEP_SIZE
-- Performing Test HAVE_FALLOC_PUNCH_HOLE_AND_KEEP_SIZE - Success
-- Performing Test HAVE_VFORK
-- Performing Test HAVE_VFORK - Success
-- Found ZLIB: /usr/lib/aarch64-linux-gnu/libz.so (found version "1.3.1")
-- Looking for crc32
-- Looking for crc32 - found
-- Looking for compressBound
-- Looking for compressBound - found
-- Looking for deflateBound
-- Looking for deflateBound - found
-- Found OpenSSL: /usr/lib/aarch64-linux-gnu/libcrypto.so (found version "3.5.4")
-- OPENSSL_INCLUDE_DIR = /usr/include
-- OPENSSL_SSL_LIBRARY = /usr/lib/aarch64-linux-gnu/libssl.so
-- OPENSSL_CRYPTO_LIBRARY = /usr/lib/aarch64-linux-gnu/libcrypto.so
-- OPENSSL_VERSION = 3.5.4
-- SSL_LIBRARIES = /usr/lib/aarch64-linux-gnu/libssl.so;/usr/lib/aarch64-linux-gnu/libcrypto.so
-- Looking for ERR_remove_thread_state
-- Looking for ERR_remove_thread_state - found
-- Looking for EVP_aes_128_ctr
-- Looking for EVP_aes_128_ctr - found
-- Looking for EVP_aes_128_gcm
-- Looking for EVP_aes_128_gcm - found
-- Looking for DES_set_key_unchecked
-- Looking for DES_set_key_unchecked - found
-- Looking for EVP_PKEY_get_raw_public_key
-- Looking for EVP_PKEY_get_raw_public_key - found
-- Looking for EVP_PKEY_CTX_set_hkdf_md
-- Looking for EVP_PKEY_CTX_set_hkdf_md - found
-- Check size of mbstate_t
-- Check size of mbstate_t - done
-- Looking for mbrlen
-- Looking for mbrlen - found
-- Looking for mbsrtowcs
-- Looking for mbsrtowcs - found
-- Looking for mbrtowc
-- Looking for mbrtowc - found
-- Looking for wcwidth
-- Looking for wcwidth - found
-- Looking for iswlower
-- Looking for iswlower - found
-- Looking for iswupper
-- Looking for iswupper - found
-- Looking for towlower
-- Looking for towlower - found
-- Looking for towupper
-- Looking for towupper - found
-- Looking for iswctype
-- Looking for iswctype - found
-- Check size of wchar_t
-- Check size of wchar_t - done
-- Check size of wctype_t
-- Check size of wctype_t - done
-- Check size of wint_t
-- Check size of wint_t - done
-- Found Curses: /usr/lib/aarch64-linux-gnu/libcurses.so
-- Looking for tputs in /usr/lib/aarch64-linux-gnu/libcurses.so
-- Looking for tputs in /usr/lib/aarch64-linux-gnu/libcurses.so - found
-- Looking for setupterm in /usr/lib/aarch64-linux-gnu/libcurses.so
-- Looking for setupterm in /usr/lib/aarch64-linux-gnu/libcurses.so - found
-- Looking for vidattr in /usr/lib/aarch64-linux-gnu/libcurses.so
-- Looking for vidattr in /usr/lib/aarch64-linux-gnu/libcurses.so - found
-- Performing Test NEW_READLINE_INTERFACE
-- Performing Test NEW_READLINE_INTERFACE - Success
-- Performing Test READLINE_V5
-- Performing Test READLINE_V5 - Failed
-- Performing Test LIBEDIT_HAVE_COMPLETION_INT
-- Performing Test LIBEDIT_HAVE_COMPLETION_INT - Failed
-- Performing Test LIBEDIT_HAVE_COMPLETION_CHAR
-- Performing Test LIBEDIT_HAVE_COMPLETION_CHAR - Success
-- Performing Test HAVE_HIST_ENTRY
-- Performing Test HAVE_HIST_ENTRY - Success
-- Looking for include files curses.h, term.h
-- Looking for include files curses.h, term.h - found
-- Checking for module 'libpcre2-8'
--   Found libpcre2-8, version 10.46
-- Looking for pcre2_match_8 in pcre2-8
-- Looking for pcre2_match_8 in pcre2-8 - found
-- Looking for PCRE2regcomp in pcre2-posix
-- Looking for PCRE2regcomp in pcre2-posix - not found
-- Performing Test HAVE_SYSTEM_LIBFMT
-- Performing Test HAVE_SYSTEM_LIBFMT - Success
-- Looking for io_uring_mlock_size
-- Looking for io_uring_mlock_size - found
-- Found PkgConfig: /usr/bin/pkg-config (found version "1.8.1")
-- Checking for one of the modules 'libsystemd;libsystemd-daemon'
-- Looking for sd_listen_fds in systemd
-- Looking for sd_listen_fds in systemd - found
-- Looking for sd_listen_fds_with_names in systemd
-- Looking for sd_listen_fds_with_names in systemd - found
-- Looking for include file systemd/sd-daemon.h
-- Looking for include file systemd/sd-daemon.h - found
-- Looking for sd_notify
-- Looking for sd_notify - found
-- Looking for sd_notifyf
-- Looking for sd_notifyf - found
-- Systemd features enabled
-- Performing Test have_C__Wall
-- Performing Test have_C__Wall - Success
-- Performing Test have_CXX__Wall
-- Performing Test have_CXX__Wall - Success
-- Performing Test have_C__Wdeclaration_after_statement
-- Performing Test have_C__Wdeclaration_after_statement - Success
-- Performing Test have_CXX__Wdeclaration_after_statement
-- Performing Test have_CXX__Wdeclaration_after_statement - Failed
-- Performing Test have_C__Wenum_compare
-- Performing Test have_C__Wenum_compare - Success
-- Performing Test have_CXX__Wenum_compare
-- Performing Test have_CXX__Wenum_compare - Success
-- Performing Test have_C__Wenum_conversion
-- Performing Test have_C__Wenum_conversion - Success
-- Performing Test have_CXX__Wenum_conversion
-- Performing Test have_CXX__Wenum_conversion - Success
-- Performing Test have_C__Wextra
-- Performing Test have_C__Wextra - Success
-- Performing Test have_CXX__Wextra
-- Performing Test have_CXX__Wextra - Success
-- Performing Test have_C__Wformat_security
-- Performing Test have_C__Wformat_security - Failed
-- Performing Test have_CXX__Wformat_security
-- Performing Test have_CXX__Wformat_security - Failed
-- Performing Test have_C__Winconsistent_missing_override
-- Performing Test have_C__Winconsistent_missing_override - Failed
-- Performing Test have_CXX__Winconsistent_missing_override
-- Performing Test have_CXX__Winconsistent_missing_override - Failed
-- Performing Test have_C__Wmissing_braces
-- Performing Test have_C__Wmissing_braces - Success
-- Performing Test have_CXX__Wmissing_braces
-- Performing Test have_CXX__Wmissing_braces - Success
-- Performing Test have_C__Wformat_truncation
-- Performing Test have_C__Wformat_truncation - Success
-- Performing Test have_CXX__Wformat_truncation
-- Performing Test have_CXX__Wformat_truncation - Success
-- Performing Test have_C__Winit_self
-- Performing Test have_C__Winit_self - Success
-- Performing Test have_CXX__Winit_self
-- Performing Test have_CXX__Winit_self - Success
-- Performing Test have_C__Wnonnull_compare
-- Performing Test have_C__Wnonnull_compare - Success
-- Performing Test have_CXX__Wnonnull_compare
-- Performing Test have_CXX__Wnonnull_compare - Success
-- Performing Test have_C__Wnull_conversion
-- Performing Test have_C__Wnull_conversion - Failed
-- Performing Test have_CXX__Wnull_conversion
-- Performing Test have_CXX__Wnull_conversion - Failed
-- Performing Test have_C__Wunused_parameter
-- Performing Test have_C__Wunused_parameter - Success
-- Performing Test have_CXX__Wunused_parameter
-- Performing Test have_CXX__Wunused_parameter - Success
-- Performing Test have_C__Wunused_private_field
-- Performing Test have_C__Wunused_private_field - Failed
-- Performing Test have_CXX__Wunused_private_field
-- Performing Test have_CXX__Wunused_private_field - Failed
-- Performing Test have_C__Wnon_virtual_dtor
-- Performing Test have_C__Wnon_virtual_dtor - Failed
-- Performing Test have_CXX__Wnon_virtual_dtor
-- Performing Test have_CXX__Wnon_virtual_dtor - Success
-- Performing Test have_C__Woverloaded_virtual
-- Performing Test have_C__Woverloaded_virtual - Failed
-- Performing Test have_CXX__Woverloaded_virtual
-- Performing Test have_CXX__Woverloaded_virtual - Success
-- Performing Test have_C__Wvla
-- Performing Test have_C__Wvla - Success
-- Performing Test have_CXX__Wvla
-- Performing Test have_CXX__Wvla - Success
-- Performing Test have_C__Wwrite_strings
-- Performing Test have_C__Wwrite_strings - Success
-- Performing Test have_CXX__Wwrite_strings
-- Performing Test have_CXX__Wwrite_strings - Success
-- Performing Test have_C__Wcast_function_type_strict
-- Performing Test have_C__Wcast_function_type_strict - Failed
-- Performing Test have_CXX__Wcast_function_type_strict
-- Performing Test have_CXX__Wcast_function_type_strict - Failed
-- Performing Test have_C__Wframe_larger_than_16384
-- Performing Test have_C__Wframe_larger_than_16384 - Success
-- Performing Test have_CXX__Wframe_larger_than_16384
-- Performing Test have_CXX__Wframe_larger_than_16384 - Success
-- Performing Test have_CXX__Werror
-- Performing Test have_CXX__Werror - Success
-- Performing Test have_C__fno_operator_names
-- Performing Test have_C__fno_operator_names - Failed
-- Performing Test have_CXX__fno_operator_names
-- Performing Test have_CXX__fno_operator_names - Success
-- Performing Test have_C__Wsuggest_override
-- Performing Test have_C__Wsuggest_override - Failed
-- Performing Test have_CXX__Wsuggest_override
-- Performing Test have_CXX__Wsuggest_override - Success
-- Looking for include file threads.h
-- Looking for include file threads.h - found
== Configuring MariaDB Connector/C
-- Found CURL: /usr/lib/aarch64-linux-gnu/libcurl.so (found version "8.16.0")
-- Performing Test HAS_-Wunused_FLAG
-- Performing Test HAS_-Wunused_FLAG - Success
-- Performing Test HAS_-Wlogical-op_FLAG
-- Performing Test HAS_-Wlogical-op_FLAG - Success
-- Performing Test HAS_-Wno-uninitialized_FLAG
-- Performing Test HAS_-Wno-uninitialized_FLAG - Success
-- Performing Test HAS_-Wall_FLAG
-- Performing Test HAS_-Wall_FLAG - Success
-- Performing Test HAS_-Wextra_FLAG
-- Performing Test HAS_-Wextra_FLAG - Success
-- Performing Test HAS_-Wformat-security_FLAG
-- Performing Test HAS_-Wformat-security_FLAG - Success
-- Performing Test HAS_-Wno-init-self_FLAG
-- Performing Test HAS_-Wno-init-self_FLAG - Success
-- Performing Test HAS_-Wwrite-strings_FLAG
-- Performing Test HAS_-Wwrite-strings_FLAG - Success
-- Performing Test HAS_-Wshift-count-overflow_FLAG
-- Performing Test HAS_-Wshift-count-overflow_FLAG - Success
-- Performing Test HAS_-Wdeclaration-after-statement_FLAG
-- Performing Test HAS_-Wdeclaration-after-statement_FLAG - Success
-- Performing Test HAS_-Wno-undef_FLAG
-- Performing Test HAS_-Wno-undef_FLAG - Success
-- Performing Test HAS_-Wno-unknown-pragmas_FLAG
-- Performing Test HAS_-Wno-unknown-pragmas_FLAG - Success
-- Performing Test HAS_-Wno-stringop-truncation_FLAG
-- Performing Test HAS_-Wno-stringop-truncation_FLAG - Success
-- MariaDB Connector C: INSTALL_BINDIR=bin
-- MariaDB Connector C: INSTALL_LIBDIR=lib
-- MariaDB Connector C: INSTALL_PCDIR=lib/pkgconfig
-- MariaDB Connector C: INSTALL_INCLUDEDIR=include/mysql
-- MariaDB Connector C: INSTALL_DOCSDIR=
-- MariaDB Connector C: INSTALL_PLUGINDIR=lib/plugin
-- MariaDB Connector C: INSTALL_MANDIR=man
-- MariaDB Connector C: LIBMARIADB_STATIC_NAME mariadbclient
-- Found ZSTD: /usr/lib/aarch64-linux-gnu/libzstd.so
-- Looking for include file linux/limits.h
-- Looking for include file linux/limits.h - found
-- Looking for include file signal.h
-- Looking for include file signal.h - found
-- Looking for include file ucontext.h
-- Looking for include file ucontext.h - found
-- Looking for makecontext
-- Looking for makecontext - found
-- Check size of ushort
-- Check size of ushort - done
-- Check size of socklen_t
-- Check size of socklen_t - failed
-- Looking for floor
-- Looking for floor - not found
-- Looking for pthread_getspecific
-- Looking for pthread_getspecific - found
-- Looking for gethostbyname_r
-- Looking for gethostbyname_r - found
-- Looking for setsockopt
-- Looking for setsockopt - found
-- TLS library/version: OpenSSL 3.5.4
-- SYSTEM_LIBS /usr/lib/aarch64-linux-gnu/libz.so;dl;m;dl;m;/usr/lib/aarch64-linux-gnu/libssl.so;/usr/lib/aarch64-linux-gnu/libcrypto.so
CMake Warning (dev) at libmariadb/cmake/FindGSSAPI.cmake:64 (exec_program):
  Policy CMP0153 is not set: The exec_program command should not be called.
  Run "cmake --help-policy CMP0153" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  Use execute_process() instead.
Call Stack (most recent call first):
  libmariadb/CMakeLists.txt:440 (INCLUDE)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at libmariadb/cmake/FindGSSAPI.cmake:74 (exec_program):
  Policy CMP0153 is not set: The exec_program command should not be called.
  Run "cmake --help-policy CMP0153" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  Use execute_process() instead.
Call Stack (most recent call first):
  libmariadb/CMakeLists.txt:440 (INCLUDE)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at libmariadb/cmake/FindGSSAPI.cmake:78 (exec_program):
  Policy CMP0153 is not set: The exec_program command should not be called.
  Run "cmake --help-policy CMP0153" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  Use execute_process() instead.
Call Stack (most recent call first):
  libmariadb/CMakeLists.txt:440 (INCLUDE)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Found GSSAPI: -L/usr/lib/aarch64-linux-gnu/mit-krb5 -lgssapi_krb5 -lkrb5 -lk5crypto -lcom_err
-- Performing Test have__Wl___as_needed
-- Performing Test have__Wl___as_needed - Success
-- SYSTEM_LIBS: /usr/lib/aarch64-linux-gnu/libz.so;dl;m;dl;m;/usr/lib/aarch64-linux-gnu/libssl.so;/usr/lib/aarch64-linux-gnu/libcrypto.so;/usr/lib/aarch64-linux-gnu/libz.so
-- Found Python3: /usr/bin/python3 (found version "3.13.9") found components: Interpreter
/usr/bin/python3: No module named pip
-- SYSTEM processor: aarch64
-- MariaDB Connector/c configuration:
-- Static PLUGINS mysql_native_password;mysql_old_password;zlib;pvio_socket
-- Dynamic PLUGINS dialog;client_ed25519;caching_sha2_password;sha256_password;parsec;auth_gssapi_client;mysql_clear_password;zstd
-- Disabled PLUGINS mysql_old_password
-- CPack generation: TGZ
-- SSL support: OPENSSL Libs: /usr/lib/aarch64-linux-gnu/libssl.so;/usr/lib/aarch64-linux-gnu/libcrypto.so
-- Zlib support: ON
-- ZStd support: TRUE
-- Installation layout: DEFAULT
-- Include files will be installed in include/mysql
-- Libraries will be installed in lib
-- Binaries will be installed in bin
-- Required: /usr/lib/aarch64-linux-gnu/libz.so;dl;m
-- MariaDB Connector/C 3.4.7
-- Looking for include file numa.h
-- Looking for include file numa.h - found
-- Looking for include file numaif.h
-- Looking for include file numaif.h - found
-- Performing Test HAVE_LIBNUMA
-- Performing Test HAVE_LIBNUMA - Success
-- WITH_NUMA=AUTO: NUMA memory allocation policy enabled
-- Looking for regcomp
-- Looking for regcomp - found
-- Performing Test have_C__Wframe_larger_than_49152
-- Performing Test have_C__Wframe_larger_than_49152 - Success
-- Performing Test have_CXX__Wframe_larger_than_49152
-- Performing Test have_CXX__Wframe_larger_than_49152 - Success
-- Configuring OQGraph
CMake Warning (dev) at storage/oqgraph/CMakeLists.txt:12 (FIND_PACKAGE):
  Policy CMP0167 is not set: The FindBoost module is removed.  Run "cmake
  --help-policy CMP0167" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

Call Stack (most recent call first):
  storage/oqgraph/CMakeLists.txt:43 (CHECK_OQGRAPH)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Found Boost: /usr/lib/aarch64-linux-gnu/cmake/Boost-1.83.0/BoostConfig.cmake (found suitable version "1.83.0", minimum required is "1.40.0")
-- Found libjudy: /usr/lib/aarch64-linux-gnu/libJudy.so
-- Performing Test HAVE_PTHREAD_THREADID_NP
-- Performing Test HAVE_PTHREAD_THREADID_NP - Failed
-- Looking for gettid
-- Looking for gettid - not found
-- Performing Test HAVE_SYS_GETTID
-- Performing Test HAVE_SYS_GETTID - Success
-- Performing Test HAVE_GETTHRID
-- Performing Test HAVE_GETTHRID - Failed
-- Performing Test HAVE_PTHREAD_GETTHREADID_NP
-- Performing Test HAVE_PTHREAD_GETTHREADID_NP - Failed
-- Performing Test HAVE_INTEGER_PTHREAD_SELF
-- Performing Test HAVE_INTEGER_PTHREAD_SELF - Success
-- Looking for krb5_xfree
-- Looking for krb5_xfree - not found
-- Performing Test have_C__Wl___as_needed
-- Performing Test have_C__Wl___as_needed - Success
-- Performing Test have_CXX__Wl___as_needed
-- Performing Test have_CXX__Wl___as_needed - Success
-- Looking for include file security/pam_ext.h
-- Looking for include file security/pam_ext.h - found
-- Looking for include file security/pam_appl.h
-- Looking for include file security/pam_appl.h - found
-- Looking for strndup
-- Looking for strndup - found
-- Looking for getgrouplist
-- Looking for getgrouplist - found
-- Performing Test HAVE_POSIX_GETGROUPLIST
-- Performing Test HAVE_POSIX_GETGROUPLIST - Success
-- Looking for pam_syslog
-- Looking for pam_syslog - found
-- Performing Test HAVE_PEERCRED
-- Performing Test HAVE_PEERCRED - Success
-- Can't build aws_key_management - AWS SDK not available (AWS_SDK_EXTERNAL_PROJECT is not ON and aws-cpp-sdk-kms not found)
-- Looking for FascistCheckUser in crack
-- Looking for FascistCheckUser in crack - found
-- Looking for include file crack.h
-- Looking for include file crack.h - found
-- Looking for getmntent
-- Looking for getmntent - found
-- Looking for getmntent
-- Looking for getmntent - not found
-- Looking for setmntent
-- Looking for setmntent - found
-- Looking for getmntinfo
-- Looking for getmntinfo - not found
-- Looking for include file sys/mntent.h
-- Looking for include file sys/mntent.h - not found
-- Looking for include file netdb.h
-- Looking for include file netdb.h - found
-- Found BZip2: /usr/lib/aarch64-linux-gnu/libbz2.so (found version "1.0.8")
-- Looking for BZ2_bzCompressInit
-- Looking for BZ2_bzCompressInit - found
-- Found LZ4: /usr/lib/aarch64-linux-gnu/liblz4.so (found suitable version "1.10.0", minimum required is "1.6")
-- Looking for lzma_auto_decoder in /usr/lib/aarch64-linux-gnu/liblzma.so
-- Looking for lzma_auto_decoder in /usr/lib/aarch64-linux-gnu/liblzma.so - found
-- Looking for lzma_easy_encoder in /usr/lib/aarch64-linux-gnu/liblzma.so
-- Looking for lzma_easy_encoder in /usr/lib/aarch64-linux-gnu/liblzma.so - found
-- Looking for lzma_lzma_preset in /usr/lib/aarch64-linux-gnu/liblzma.so
-- Looking for lzma_lzma_preset in /usr/lib/aarch64-linux-gnu/liblzma.so - found
-- Found LibLZMA: /usr/lib/aarch64-linux-gnu/liblzma.so (found version "5.8.1")
-- Found LZO: /usr/lib/aarch64-linux-gnu/liblzo2.so
-- Found Snappy: /usr/lib/aarch64-linux-gnu/libsnappy.so
-- Performing Test HAVE_ARMV8_CRC_CRYPTO_MARCH
-- Performing Test HAVE_ARMV8_CRC_CRYPTO_MARCH - Success
-- Performing Test HAVE_ARMV8_CRC
-- Performing Test HAVE_ARMV8_CRC - Success
-- Performing Test HAVE_ARMV8_CRYPTO
-- Performing Test HAVE_ARMV8_CRYPTO - Success
-- Looking for arm_acle.h
-- Looking for arm_acle.h - found
-- Looking for event.h
-- Looking for event.h - not found
-- Found BISON: /usr/bin/bison (found suitable version "3.8.2", minimum required is "2.4")
-- Performing Test have_CXX__Wno_unused_but_set_variable
-- Performing Test have_CXX__Wno_unused_but_set_variable - Success
The following features have been enabled:

 * SYSTEMD, Systemd scripts and notification support
 * ARCHIVE, Storage Engine MODULE
 * BLACKHOLE, Storage Engine MODULE
 * CSV, Storage Engine STATIC
 * EXAMPLE, Storage Engine MODULE
 * FEDERATED, Storage Engine MODULE
 * FEDERATEDX, Storage Engine MODULE
 * HEAP, Storage Engine STATIC
 * NUMA, NUMA memory allocation policy
 * INNODB_AHI, InnoDB Adaptive Hash Index
 * INNODB_ROOT_GUESS, Cache index root block descriptors in InnoDB
 * INNOBASE, Storage Engine STATIC
 * MARIABACKUP, MariaDB Backup Utility
 * ARIA, Storage Engine STATIC
 * MYISAM, Storage Engine STATIC
 * MYISAMMRG, Storage Engine STATIC
 * OQGRAPH, Storage Engine MODULE
 * SEQUENCE, Storage Engine STATIC
 * SPHINX, Storage Engine MODULE
 * SPIDER, Storage Engine MODULE
 * TEST_SQL_DISCOVERY, Storage Engine MODULE
 * VIDEX, Storage Engine STATIC
 * AUDIT_NULL, Server plugin MODULE
 * AUTH_ED25519, Server plugin MODULE
 * DIALOG_EXAMPLES, Server plugin MODULE
 * AUTH_TEST_PLUGIN, Server plugin MODULE
 * QA_AUTH_INTERFACE, Server plugin MODULE
 * QA_AUTH_SERVER, Server plugin MODULE
 * QA_AUTH_CLIENT, Server plugin MODULE
 * AUTH_0X0100, Server plugin MODULE
 * AUTH_GSSAPI, Server plugin MODULE
 * AUTH_MYSQL_SHA2, Server plugin MODULE
 * AUTH_PAM_V1, Server plugin MODULE
 * AUTH_PAM, Server plugin MODULE
 * AUTH_PARSEC, Server plugin MODULE
 * AUTH_SOCKET, Server plugin STATIC
 * CRACKLIB_PASSWORD_CHECK, Server plugin MODULE
 * DAEMON_EXAMPLE, Server plugin MODULE
 * DEBUG_KEY_MANAGEMENT, Server plugin MODULE
 * DISKS, Server plugin MODULE
 * EXAMPLE_KEY_MANAGEMENT, Server plugin MODULE
 * FEEDBACK, Server plugin STATIC
 * FILE_KEY_MANAGEMENT, Server plugin MODULE
 * FTEXAMPLE, Server plugin MODULE
 * FUNC_TEST, Server plugin MODULE
 * HANDLERSOCKET, Server plugin MODULE
 * HASHICORP_KEY_MANAGEMENT, Hashicorp Key Management Plugin
 * LOCALES, Server plugin MODULE
 * METADATA_LOCK_INFO, Server plugin MODULE
 * PASSWORD_REUSE_CHECK, Server plugin MODULE
 * PROVIDER_BZIP2, Server plugin MODULE
 * PROVIDER_LZ4, Server plugin MODULE
 * PROVIDER_LZMA, Server plugin MODULE
 * PROVIDER_LZO, Server plugin MODULE
 * PROVIDER_SNAPPY, Server plugin MODULE
 * QUERY_CACHE_INFO, Server plugin MODULE
 * QUERY_RESPONSE_TIME, Server plugin MODULE
 * SERVER_AUDIT, Server plugin MODULE
 * SIMPLE_PASSWORD_CHECK, Server plugin MODULE
 * SQL_ERRLOG, Server plugin MODULE
 * TEST_SQL_SERVICE, Server plugin MODULE
 * TYPE_GEOM, Server plugin STATIC
 * TYPE_INET, Server plugin STATIC
 * TYPE_MYSQL_JSON, Server plugin MODULE
 * TYPE_MYSQL_TIMESTAMP, Server plugin MODULE
 * TYPE_TEST, Server plugin MODULE
 * TYPE_UUID, Server plugin STATIC
 * USER_VARIABLES, Server plugin STATIC
 * USERSTAT, Server plugin STATIC
 * TEST_VERSIONING, Server plugin MODULE
 * THREAD_POOL_INFO, Server plugin STATIC
 * PARTITION, Storage Engine STATIC
 * SQL_SEQUENCE, Storage Engine STATIC
 * ONLINE_ALTER_LOG, Storage Engine STATIC

-- The following OPTIONAL packages have been found:

 * Git
 * ZLIB
 * Threads
 * Python3
 * Boost (required version >= 1.40.0)
   Required for the OQGraph storage engine
 * Judy
   Required for the OQGraph storage engine
 * GSSAPI
 * BZip2
 * LZ4 (required version >= 1.6)
 * LibLZMA
 * LZO
 * Snappy
 * BISON (required version >= 2.4)

-- The following RECOMMENDED packages have been found:

 * OpenSSL

-- The following REQUIRED packages have been found:

 * Curses
 * CURL

-- The following features have been disabled:

 * WSREP, WSREP replication API (to use, e.g. Galera Replication library)
 * LIBWRAP, Support for tcp wrappers
 * INNODB_EXTRA_DEBUG, Extra InnoDB debug checks
 * PERFSCHEMA, Storage Engine 
 * ROCKSDB, Storage Engine
 * AWS_KEY_MANAGEMENT, AWS Encryption Key Management Plugin
 * EMBEDDED_SERVER, Embedded MariaDB Server Library

-- Configuring done (22.0s)
-- Generating done (0.4s)
-- Build files have been written to: /root/mariadb_server/mysql_build_output/build
# /usr/bin/cmake --build mysql_build_output/build --target mariadbd -j 10
[202/758] [BISON][gen_mariadb_cc_hh] Building parser with bison 3.8.2
/root/mariadb_server/mysql_build_output/build/sql/yy_mariadb.cc:36843: warning: suspicious sequence in the output: b4_bin [-Wother]
[210/758] [BISON][gen_oracle_cc_hh] Building parser with bison 3.8.2
/root/mariadb_server/mysql_build_output/build/sql/yy_oracle.cc:35745: warning: suspicious sequence in the output: b4_bin [-Wother]
[380/758] Building CXX object storage/innobase/CMakeFiles/innobase.dir/row/row0sel.cc.o
In file included from /root/mariadb_server/storage/innobase/include/mach0data.h:373,
                 from /root/mariadb_server/storage/innobase/include/data0type.inl:27,
                 from /root/mariadb_server/storage/innobase/include/data0type.h:544,
                 from /root/mariadb_server/storage/innobase/include/data0data.h:31,
                 from /root/mariadb_server/storage/innobase/include/row0sel.h:29,
                 from /root/mariadb_server/storage/innobase/row/row0sel.cc:28:
In function 'void mach_write_to_4(byte*, ulint)',
    inlined from 'void row_sel_prefetch_cache_init(row_prebuilt_t*)' at /root/mariadb_server/storage/innobase/row/row0sel.cc:3895:18,
    inlined from 'byte* row_sel_fetch_last_buf(row_prebuilt_t*)' at /root/mariadb_server/storage/innobase/row/row0sel.cc:3916:30,
    inlined from 'void row_sel_enqueue_cache_row_for_mysql(byte*, row_prebuilt_t*)' at /root/mariadb_server/storage/innobase/row/row0sel.cc:3939:32:
/root/mariadb_server/storage/innobase/include/mach0data.inl:169:14: warning: writing 8 bytes into a region of size 0 [-Wstringop-overflow=]
  169 |         b[0] = (byte)(n >> 24);
      |         ~~~~~^~~~~~~~~~~~~~~~~
In file included from /root/mariadb_server/storage/innobase/include/mem0mem.inl:27,
                 from /root/mariadb_server/storage/innobase/include/mem0mem.h:306,
                 from /root/mariadb_server/storage/innobase/include/data0data.h:32:
In function 'void row_sel_prefetch_cache_init(row_prebuilt_t*)',
    inlined from 'byte* row_sel_fetch_last_buf(row_prebuilt_t*)' at /root/mariadb_server/storage/innobase/row/row0sel.cc:3916:30,
    inlined from 'void row_sel_enqueue_cache_row_for_mysql(byte*, row_prebuilt_t*)' at /root/mariadb_server/storage/innobase/row/row0sel.cc:3939:32:
/root/mariadb_server/storage/innobase/include/ut0new.h:1067:49: note: at offset [-7, -1] into destination object of size [8, 9223372036854775807] allocated by 'malloc'
 1067 | #define ut_malloc_nokey(n_bytes)        ::malloc(n_bytes)
      |                                         ~~~~~~~~^~~~~~~~~
/root/mariadb_server/storage/innobase/row/row0sel.cc:3881:34: note: in expansion of macro 'ut_malloc_nokey'
 3881 |         ptr = static_cast<byte*>(ut_malloc_nokey(sz));
      |                                  ^~~~~~~~~~~~~~~
[758/758] Linking CXX executable sql/mariadbd
# 
```



---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to VIDEX! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Core]</code>: Changes to core engine functionality</li>
    <li><code>[Opt]</code>: Changes to VIDEX-Optimizer-Plugin</li>
    <li><code>[Stats]</code>: Changes to VIDEX-Statistic-Server</li>
    <li><code>[Algo]</code>: Implementation of new algorithms for NDV, cardinality estimation, etc.</li>
    <li><code>[Pipe]</code>: Enhancements to the pipeline (e.g., data collection, environment setup)</li>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[Test]</code>: Adding or updating tests</li>
    <li><code>[Perf]</code>: Performance improvements</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use the most specific prefix or multiple prefixes in order of importance (e.g., [Algorithm][Stats]).</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Changes have been tested on both Plugin-Mode and Standalone-Mode (if applicable)</li>
    <li>[ ] Statistical accuracy has been verified (for algorithm or optimizer changes)</li>
    <li>[ ] No regression in query plan accuracy compared to InnoDB (if applicable)</li>
    <li>[ ] Performance benchmarks conducted (for performance-sensitive changes)</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>
