### PR TITLE
Docker: Add a separate videx-server image to support launching the server and executing the videx-sync scripts.

### DIFF
--- a/build/Dockerfile.videxserver
+++ b/build/Dockerfile.videxserver
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.11-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/build/Dockerfile.videxserver
+++ b/build/Dockerfile.videxserver
@@ -12,7 +12,13 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /opt/videx
 
 COPY requirements.txt /opt/videx/requirements.txt
-RUN pip install -r /opt/videx/requirements.txt
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        gcc \
+        python3-dev \
+    && pip install -r /opt/videx/requirements.txt \
+    && apt-get purge -y --auto-remove gcc python3-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY src/ /opt/videx/src/
 COPY build/videx_container_entrypoint.py /opt/videx/videx_container_entrypoint.py

--- a/build/Dockerfile.videxserver
+++ b/build/Dockerfile.videxserver
@@ -1,12 +1,10 @@
-# Thanks to Daniel Black for providing a great packaging example.
-
-
 FROM python:3.9-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1 \
+    VIDEX_CONTAINER=1 \
     PYTHONPATH=/opt/videx/src
 
 WORKDIR /opt/videx

--- a/build/Dockerfile.videxserver
+++ b/build/Dockerfile.videxserver
@@ -1,0 +1,24 @@
+# Thanks to Daniel Black for providing a great packaging example.
+
+
+FROM python:3.9-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONPATH=/opt/videx/src
+
+WORKDIR /opt/videx
+
+COPY requirements.txt /opt/videx/requirements.txt
+RUN pip install -r /opt/videx/requirements.txt
+
+COPY src/ /opt/videx/src/
+COPY build/videx_container_entrypoint.py /opt/videx/videx_container_entrypoint.py
+
+# Default/documentation port. You can still map any host port to container 5001 via -p HOST:5001.
+EXPOSE 5001
+
+ENTRYPOINT ["python", "/opt/videx/videx_container_entrypoint.py"]
+CMD ["server"]

--- a/build/videx_container_entrypoint.py
+++ b/build/videx_container_entrypoint.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+VIDEX Docker entrypoint.
+
+This entrypoint provides two modes:
+- `server`: start the long-running VIDEX stats server (default)
+- `sync`:   run the one-shot sync/env build script and exit
+
+Design notes:
+- Keep argument handling minimal.
+- Do not rewrite user arguments.
+- Best-effort warnings are emitted for common container networking pitfalls
+  (e.g. using localhost/127.0.0.1 in --target inside a container).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import subprocess
+from typing import List, Optional, Tuple
+
+LOCALHOST_NAMES = {"127.0.0.1", "localhost", "::1"}
+
+
+def _in_container_best_effort() -> bool:
+    """
+    Best-effort heuristics to detect container environment.
+    Used only for warnings (never for rewriting args or failing).
+    """
+    if os.path.exists("/.dockerenv"):
+        return True
+
+    if os.environ.get("container"):
+        return True
+
+    try:
+        with open("/proc/1/cgroup", "rt", encoding="utf-8") as f:
+            c = f.read()
+        hints = ("docker", "containerd", "kubepods", "podman")
+        return any(h in c for h in hints)
+    except OSError:
+        return False
+
+
+def _usage() -> str:
+    return (
+        "Usage:\n"
+        "  <image> [server]\n"
+        "  <image> sync --target HOST:PORT:DB:USER:PASS [--videx ...] [other args]\n"
+        "\n"
+        "Commands:\n"
+        "  server   Start VIDEX server (default).\n"
+        "  sync     Run one-shot scripts to collect metadata from --target, then add metadata into videx-server, and create virtual tables in --videx.\n"
+        "\n"
+        "Notes:\n"
+        "  In a container, 127.0.0.1/localhost refers to the container itself.\n"
+        "  See doc/VIDEX_SERVER_DOCKER.md for Docker networking tips.\n"
+    )
+
+
+def _extract_flag_value(argv: List[str], name: str) -> Tuple[Optional[str], bool]:
+    """
+    Extract the value of a CLI flag from argv, supporting:
+      --name value
+      --name=value
+
+    Returns (value, present):
+      - present=False => flag not present
+      - present=True and value=None => flag present but missing value
+    """
+    for i, tok in enumerate(argv):
+        if tok == name:
+            if i + 1 >= len(argv) or argv[i + 1].startswith("--"):
+                return None, True
+            return argv[i + 1], True
+        if tok.startswith(name + "="):
+            return tok.split("=", 1)[1], True
+    return None, False
+
+
+def _parse_target_host(target: str) -> Optional[str]:
+    """
+    Parse host from a connection string of form:
+      host:port:db:user:password
+
+    We only need host for warnings, so do not over-validate.
+    If format is unexpected, return None.
+    """
+    if not target or ":" not in target:
+        return None
+    host = target.split(":", 1)[0].strip()
+    return host or None
+
+
+def _maybe_warn_localhost_target(argv: List[str]) -> None:
+    """
+    Print best-effort warnings about using localhost/127.0.0.1 inside containers.
+    No rewriting; no hard failure.
+    """
+    target, present = _extract_flag_value(argv, "--target")
+
+    if not present:
+        sys.stderr.write(
+            "Warning: 'sync' usually needs --target HOST:PORT:DB:USER:PASS.\n"
+            "         The sync script will likely fail without it.\n\n"
+        )
+        return
+
+    if target is None:
+        sys.stderr.write(
+            "Warning: '--target' flag is present but has no value.\n"
+            "         The sync script will likely fail. Usage:\n\n"
+            f"{_usage()}\n"
+        )
+        return
+
+    host = _parse_target_host(target)
+    if not host or host not in LOCALHOST_NAMES:
+        return
+
+    if not _in_container_best_effort():
+        return
+
+    sys.stderr.write(
+        "Warning: You may be running in a container, but the `--target` parameter is configured with 127.0.0.1/localhost.\n"
+        "         In Docker, localhost usually refers to the container itself.\n"
+        "         If your MariaDB/VIDEX runs on the Docker host, this may fail.\n\n"
+        "Suggestions:\n"
+        "  - Docker Desktop (Mac/Windows): try host.docker.internal in --target.\n"
+        "  - Linux Docker Engine: add this when running the container:\n"
+        "      --add-host=host.docker.internal:host-gateway\n"
+        "    then use host.docker.internal in --target.\n"
+        "  - If DB runs in the same container / same network namespace, localhost can be correct.\n\n"
+    )
+
+
+def _run_module(module: str, argv: List[str]) -> int:
+    cmd = [sys.executable, "-m", module] + argv
+    return subprocess.call(cmd)
+
+
+def _run_server(argv: List[str]) -> int:
+    # Runs: python -m sub_platforms.sql_opt.videx.scripts.start_videx_server ...
+    return _run_module("sub_platforms.sql_opt.videx.scripts.start_videx_server", argv)
+
+
+def _run_sync(argv: List[str]) -> int:
+    # Runs: python -m sub_platforms.sql_opt.videx.scripts.videx_build_env ...
+    return _run_module("sub_platforms.sql_opt.videx.scripts.videx_build_env", argv)
+
+
+def main() -> int:
+    if len(sys.argv) <= 1:
+        return _run_server([])
+
+    subcmd = sys.argv[1]
+    argv = sys.argv[2:]
+
+    if subcmd in ("-h", "--help", "help"):
+        sys.stdout.write(_usage())
+        return 0
+
+    if subcmd == "server":
+        return _run_server(argv)
+
+    if subcmd == "sync":
+        _maybe_warn_localhost_target(argv)
+        return _run_sync(argv)
+
+    # Convenience: if user passes flags without 'server', treat as server args.
+    if subcmd.startswith("-"):
+        return _run_server([subcmd] + argv)
+
+    sys.stderr.write(f"Error: unknown command '{subcmd}'.\n\n{_usage()}\n")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build/videx_container_entrypoint.py
+++ b/build/videx_container_entrypoint.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python3
 """
-VIDEX Docker entrypoint.
+VIDEX container entrypoint.
 
 This entrypoint provides two modes:
 - `server`: start the long-running VIDEX stats server (default)
@@ -28,6 +27,10 @@ def _in_container_best_effort() -> bool:
     Best-effort heuristics to detect container environment.
     Used only for warnings (never for rewriting args or failing).
     """
+    explicit = os.environ.get("VIDEX_CONTAINER")
+    if explicit and explicit.strip().lower() not in {"0", "false", "no"}:
+        return True
+
     if os.path.exists("/.dockerenv"):
         return True
 
@@ -124,8 +127,8 @@ def _maybe_warn_localhost_target(argv: List[str]) -> None:
 
     sys.stderr.write(
         "Warning: You may be running in a container, but the `--target` parameter is configured with 127.0.0.1/localhost.\n"
-        "         In Docker, localhost usually refers to the container itself.\n"
-        "         If your MariaDB/VIDEX runs on the Docker host, this may fail.\n\n"
+        "         In a container, localhost usually refers to the container itself.\n"
+        "         If your MariaDB/VIDEX runs on the host machine, this may fail.\n\n"
         "Suggestions:\n"
         "  - Docker Desktop (Mac/Windows): try host.docker.internal in --target.\n"
         "  - Linux Docker Engine: add this when running the container:\n"

--- a/doc/VIDEX_SERVER_DOCKER.md
+++ b/doc/VIDEX_SERVER_DOCKER.md
@@ -2,11 +2,7 @@
 
 The latest public image is:
 
-- `kangrongme/videx-server:0.2.0` (Docker Hub)
-
-Make sure your environment can reach Docker Hub. If Docker Hub is not accessible but GHCR is, use:
-
-- `ghcr.io/kr11/videx-server:0.2.0`
+- `ghcr.io/bytedance/videx-server:0.2.0-preview-test1` (GHCR)
 
 This image supports two entrypoint modes:
 
@@ -42,7 +38,7 @@ Expose container port `5001` to a host port (choose any free host port, like 500
 ```bash
 docker run -d --name videx-server \
   -p 5001:5001 \
-  kangrongme/videx-server:0.2.0
+  ghcr.io/bytedance/videx-server:0.2.0-preview-test1
 ```
 
 Then open:
@@ -60,7 +56,7 @@ Then open:
 
 ```bash
 docker run --rm --name videx-sync \
-  kangrongme/videx-server:0.2.0 sync \
+  ghcr.io/bytedance/videx-server:0.2.0-preview-test1 sync \
   --target <TARGET_HOST>:<TARGET_PORT>:<TARGET_DB>:<TARGET_USER>:<TARGET_PASS> \
   [--videx <VIDEX_HOST>:<VIDEX_PORT>:<VIDEX_DB>:<VIDEX_USER>:<VIDEX_PASS>] \
   [--videx_server <VIDEX_SERVER_HOST>:<VIDEX_SERVER_PORT>]
@@ -80,7 +76,7 @@ Run:
 
 ```bash
 docker run --rm --name videx-sync \
-  kangrongme/videx-server:0.2.0 sync \
+  ghcr.io/bytedance/videx-server:0.2.0-preview-test1 sync \
   --target 203.0.113.42:15508:tpch_tiny:videx:password \
   --videx 203.0.113.42:15508:videx_tpch_tiny:videx:password \
   --videx_server 203.0.113.42:5001
@@ -110,7 +106,7 @@ Inside a container, `localhost/127.0.0.1` refers to the container itself. If Mar
 ```bash
 docker run --rm --name videx-sync \
   --add-host=host.docker.internal:host-gateway \
-  kangrongme/videx-server:0.2.0 sync \
+  ghcr.io/bytedance/videx-server:0.2.0-preview-test1 sync \
   --target host.docker.internal:<PORT>:<DB>:<USER>:<PASS> \
   --videx host.docker.internal:<PORT>:<VIDEX_DB>:<VIDEX_USER>:<VIDEX_PASS> \
   --videx_server host.docker.internal:<VIDEX_SERVER_PORT>

--- a/doc/VIDEX_SERVER_DOCKER.md
+++ b/doc/VIDEX_SERVER_DOCKER.md
@@ -1,0 +1,121 @@
+## VIDEX-Server Docker Image Description
+
+The latest public image is:
+
+- `kangrongme/videx-server:0.2.0` (Docker Hub)
+
+Make sure your environment can reach Docker Hub. If Docker Hub is not accessible but GHCR is, use:
+
+- `ghcr.io/kr11/videx-server:0.2.0`
+
+This image supports two entrypoint modes:
+
+- `server` (default): start the VIDEX server
+- `sync`: run a one-shot workflow to collect metadata from `--target`, then add metadata into `videx-server`, and create virtual tables in `--videx`
+
+> Recommendation: prefer using a routable IP address (your host/server IP) instead of `localhost/127.0.0.1`, 
+> to make sure `videx-server` (running in a container) can be reached by `videx-sync` and MariaDB-VIDEX (including `videx-plugin`).  
+> This is especially important because MariaDB-VIDEX also needs to reach `videx-server`, e.g.:
+>
+> `SET SESSION VIDEX_SERVER_IP=<VIDEX_SERVER_IP>:<VIDEX_SERVER_PORT>;`
+
+---
+
+## Build image
+
+Build locally from this repo and tag it as `videx-server:0.2.0`:
+
+```bash
+docker build -f build/Dockerfile.videxserver -t videx-server:0.2.0 .
+```
+
+---
+
+## Quick start
+
+Suppose your machine/server IP is `203.0.113.42` (example only).
+
+### 1) Start the videx-server
+
+Expose container port `5001` to a host port (choose any free host port, like 5001):
+
+```bash
+docker run -d --name videx-server \
+  -p 5001:5001 \
+  kangrongme/videx-server:0.2.0
+```
+
+Then open:
+
+- `http://203.0.113.42:5001`
+- `http://localhost:5001` (only if you are on the same machine)
+
+---
+
+### 2) Run sync (one-shot) against MariaDB (recommended: use host/server IP)
+
+`sync` connects to `--target` (your MariaDB), collects metadata, writes metadata into `videx-server`, and creates virtual tables in `--videx`.
+
+#### Command template
+
+```bash
+docker run --rm --name videx-sync \
+  kangrongme/videx-server:0.2.0 sync \
+  --target <TARGET_HOST>:<TARGET_PORT>:<TARGET_DB>:<TARGET_USER>:<TARGET_PASS> \
+  [--videx <VIDEX_HOST>:<VIDEX_PORT>:<VIDEX_DB>:<VIDEX_USER>:<VIDEX_PASS>] \
+  [--videx_server <VIDEX_SERVER_HOST>:<VIDEX_SERVER_PORT>]
+```
+
+#### Example (fake IP shown)
+
+Suppose:
+
+- Your machine/server IP is `203.0.113.42` (example only)
+- MariaDB is reachable at `203.0.113.42:15508`
+- Source database is `tpch_tiny`
+- User/password: `videx` / `password`
+- `videx-server` is reachable at `203.0.113.42:5001`
+
+Run:
+
+```bash
+docker run --rm --name videx-sync \
+  kangrongme/videx-server:0.2.0 sync \
+  --target 203.0.113.42:15508:tpch_tiny:videx:password \
+  --videx 203.0.113.42:15508:videx_tpch_tiny:videx:password \
+  --videx_server 203.0.113.42:5001
+```
+
+#### Notes
+
+1. If `--videx` is not specified, a default database `videx_{TARGET_DB}` will be created in `--target`.
+2. If your videx-server is not the default `203.0.113.42:5001` , pass:
+   - `--videx_server <VIDEX_SERVER_HOST>:<VIDEX_SERVER_PORT>`
+3. Because MariaDB-VIDEX needs to call back into `videx-server`, you should configure a reachable server address, for example:
+   ```sql
+   SET SESSION VIDEX_SERVER_IP=<VIDEX_SERVER_IP>:<VIDEX_SERVER_PORT>;
+   ```
+   This is another reason why using a routable IP (not `localhost`) is recommended.
+
+---
+
+## FAQ
+
+### Q1: I used `localhost` / `127.0.0.1` in `--target` and it failed. Why?
+
+Inside a container, `localhost/127.0.0.1` refers to the container itself. If MariaDB runs on the Docker host (or elsewhere), the container cannot reach it via `localhost`.
+
+**Linux (Docker Engine) quick fix: use `host.docker.internal` via `--add-host`**
+
+```bash
+docker run --rm --name videx-sync \
+  --add-host=host.docker.internal:host-gateway \
+  kangrongme/videx-server:0.2.0 sync \
+  --target host.docker.internal:<PORT>:<DB>:<USER>:<PASS> \
+  --videx host.docker.internal:<PORT>:<VIDEX_DB>:<VIDEX_USER>:<VIDEX_PASS> \
+  --videx_server host.docker.internal:<VIDEX_SERVER_PORT>
+```
+
+However, you must ensure that MariaDB-VIDEX can still reach `videx-server`; 
+things get tricky if MariaDB-VIDEX itself is also running inside a container. 
+**In that case, using a routable IP is the most recommended way to ensure reachability.**

--- a/doc/videx-storage-engine.md
+++ b/doc/videx-storage-engine.md
@@ -1,0 +1,313 @@
+# VIDEX for MariaDB: Plugin + VIDEX-Server
+
+This document explains how to install and use **VIDEX** with MariaDB, including:
+
+- Installing/enabling the **VIDEX plugin** in MariaDB
+- Running the **VIDEX-Server** (statistics service) as a container
+- Running a one-shot **videx-sync** workflow to build a VIDEX database
+- Comparing `EXPLAIN` between your original schema and the VIDEX schema
+
+If you are looking for the VIDEX server repository (more examples and extension points), see:
+
+- VIDEX server repository: `https://github.com/bytedance/videx/`
+- Example dataset (TPC-H tiny): `https://github.com/bytedance/videx/blob/main/data/tpch_tiny/tpch_tiny.sql.tar.gz`
+
+---
+
+## Prerequisites
+
+- A running MariaDB server you can connect to (the “target”).
+- A MariaDB build that includes the `VIDEX` engine plugin (the “MariaDB-VIDEX”).
+  - For a quick start, the target MariaDB and MariaDB-VIDEX can be the same instance.
+- Docker (to run VIDEX-Server and videx-sync).
+
+## 1. What is VIDEX
+
+VIDEX is a **virtual/hypothetical index engine** for what-if analysis.
+
+- **Goal**: Evaluate how potential indexes (and optimizer decisions such as join orders) would change query plans *without creating real indexes on production data*.
+- **How it works**: VIDEX replays optimizer / handler calls using **statistics** (cardinality, NDV, histograms, etc.) instead of reading table data. Complex statistics computation is offloaded to an external service (**VIDEX-Server**) via HTTP.
+
+In practice, you keep your existing MariaDB schema and data as the “target”, and create a second schema whose tables use `ENGINE=VIDEX`. You then run `EXPLAIN` on both schemas and compare plans.
+
+> Research note (AI4DB)
+>
+> Estimating **multi-column joint NDV (Number of Distinct Value)** and **cardinality** is a challenging research problem. You can extend VIDEX by implementing your own estimation models in **VIDEX-Server** to improve accuracy for your workload.
+
+---
+
+## 2. Components and roles
+
+VIDEX typically involves the following roles:
+
+- **Target MariaDB**: your original database instance and schema (contains real data).
+- **MariaDB with VIDEX plugin** ("MariaDB-VIDEX"): a MariaDB instance that has the `VIDEX` storage engine plugin enabled.
+  - It can be the *same* instance as the Target MariaDB (common for a quick start).
+  - Or it can be a separate MariaDB instance used only for what-if analysis.
+- **VIDEX-Server**: a standalone HTTP service that stores metadata/statistics and answers estimation requests from the VIDEX plugin.
+
+This doc focuses on a **docker-based workflow** for VIDEX-Server and `videx-sync`, so users can complete the VIDEX end-to-end flow with a few `docker` commands, while the MariaDB server itself is managed by users.
+
+---
+
+## 3. Prepare sample data (TPC-H tiny)
+
+You can test VIDEX with the `TPC-H tiny` sample.
+
+1) Download `tpch_tiny.sql.tar.gz` from:
+
+`https://github.com/bytedance/videx/blob/main/data/tpch_tiny/tpch_tiny.sql.tar.gz`
+
+2) Create a database and import the data (example using `mariadb` client):
+
+```bash
+mariadb -h<TARGET_HOST> -P<TARGET_PORT> -u<TARGET_USER> -p<TARGET_PASS> \
+  -e "CREATE DATABASE tpch_tiny;"
+
+tar -zxf tpch_tiny.sql.tar.gz
+mariadb -h<TARGET_HOST> -P<TARGET_PORT> -u<TARGET_USER> -p<TARGET_PASS> \
+  -Dtpch_tiny < tpch_tiny.sql
+```
+
+---
+
+## 4. Install / enable the VIDEX plugin (MariaDB)
+
+### 4.1 Verify the engine
+
+Connect to your MariaDB instance and check whether `VIDEX` engine is available:
+
+```sql
+SHOW ENGINES;
+```
+
+If you see a row for `VIDEX` with `SUPPORT` as `YES` or `DEFAULT`, the engine is available.
+
+### 4.2 Build-time enablement
+
+If `VIDEX` is not present, build MariaDB with VIDEX enabled. The MariaDB server PR that introduced VIDEX is:
+
+`https://github.com/MariaDB/server/pull/4217`
+
+Key dependencies and options:
+
+- Dependencies:
+  - `libcurl` (HTTP client)
+  - `zlib` (compression)
+- CMake options:
+  - `-DPLUGIN_VIDEX=YES` (enable plugin)
+  - `-DPLUGIN_VIDEX=STATIC` (static)
+  - `-DPLUGIN_VIDEX=DYNAMIC` (dynamic)
+
+Example build configuration:
+
+```bash
+cmake -DPLUGIN_VIDEX=YES \
+      -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
+      -G Ninja --fresh \
+      -S /path/to/mariadb \
+      -B /path/to/build
+```
+
+---
+
+## 5. Install and run VIDEX-Server (Docker)
+
+VIDEX-Server is a separate service providing statistics/estimation over HTTP, and MariaDB-VIDEX calls it to get 
+statistics information for generating query plans.
+
+### 5.1 Images
+
+Public images:
+
+- Docker Hub: `kangrongme/videx-server:0.2.0`
+
+### 5.2 Start the server
+
+Expose container port `5001`:
+
+```bash
+docker run -d --name videx-server \
+  -p 5001:5001 \
+  kangrongme/videx-server:0.2.0
+```
+
+Then the service is reachable at:
+
+- `http://<YOUR_HOST_IP>:5001`
+
+> Reachability note
+>
+> Prefer using a **routable IP address** (your host/server IP) instead of `localhost/127.0.0.1`.
+> This matters because both MariaDB-VIDEX (the plugin) and `videx-sync` need to reach VIDEX-Server. If any of them run inside a container, `localhost/127.0.0.1` refers to that container itself (not your host), so the service will not be reachable via `localhost`.
+
+---
+
+## 6. Build the VIDEX schema (videx-sync)
+
+VIDEX-Server image supports two entrypoint modes:
+
+- `server` (default): start VIDEX-Server
+- `sync`: run a one-shot workflow to collect metadata from `--target`, then:
+  - add metadata into VIDEX-Server
+  - create virtual tables in `--videx`
+
+### 6.1 Command template
+
+```bash
+docker run --rm --name videx-sync \
+  kangrongme/videx-server:0.2.0 sync \
+  --target <TARGET_HOST>:<TARGET_PORT>:<TARGET_DB>:<TARGET_USER>:<TARGET_PASS> \
+  [--videx <VIDEX_HOST>:<VIDEX_PORT>:<VIDEX_DB>:<VIDEX_USER>:<VIDEX_PASS>] \
+  [--videx_server <VIDEX_SERVER_HOST>:<VIDEX_SERVER_PORT>]
+```
+
+Notes:
+
+1) If `--videx` is not specified, a default database `videx_{TARGET_DB}` will be created in `--target`.
+2) If you run a separate MariaDB-VIDEX instance, pass that instance as `--videx`.
+3) If your VIDEX-Server is not `<TARGET_HOST>:5001`, pass `--videx_server` explicitly.
+
+
+### 6.2 If you used localhost and it failed
+
+Inside a container, `localhost/127.0.0.1` refers to the container itself.
+
+On Linux Docker Engine, you can reach the host via `host.docker.internal` using `--add-host`:
+
+```bash
+docker run --rm --name videx-sync \
+  --add-host=host.docker.internal:host-gateway \
+  kangrongme/videx-server:0.2.0 sync \
+  --target host.docker.internal:<PORT>:<DB>:<USER>:<PASS> \
+  --videx host.docker.internal:<PORT>:<VIDEX_DB>:<VIDEX_USER>:<VIDEX_PASS> \
+  --videx_server host.docker.internal:<VIDEX_SERVER_PORT>
+```
+
+However, if MariaDB-VIDEX itself is also running in a container, reachability can become tricky.
+Using a routable IP is the most robust approach.
+
+---
+
+## 7. Configure the plugin (status/system variables)
+
+On MariaDB, the VIDEX plugin exposes **session** system variables.
+
+```sql
+SHOW VARIABLES LIKE '%videx_server_ip%';
+```
+
+Example output:
+
+```text
++-----------------+----------------+
+| Variable_name   | Value          |
++-----------------+----------------+
+| videx_server_ip | 127.0.0.1:5001 |
++-----------------+----------------+
+```
+
+- `videx_server_ip`: **critical**. The address (`host:port`) that MariaDB-VIDEX uses to call VIDEX-Server.
+
+Configure them for your current session before running `EXPLAIN` on `ENGINE=VIDEX` tables:
+
+```sql
+SET SESSION videx_server_ip = '<VIDEX_SERVER_HOST>:<VIDEX_SERVER_PORT>';
+```
+
+---
+
+## 8. Quick start (Target MariaDB == MariaDB-VIDEX)
+
+This section assumes:
+
+- Users already have **one MariaDB instance** running.
+- Users want to create the VIDEX schema **in the same instance** (so “MariaDB-VIDEX == Target MariaDB”).
+- User's MariaDB is already running and reachable.
+- The routable IP is `203.0.113.42` (example only).
+- MariaDB is reachable at `203.0.113.42:15508` (example only).
+- VIDEX-Server will be reachable at `203.0.113.42:5001` (example only).
+- User/password: `videx` / `password`.
+
+### Step 1: Start VIDEX-Server
+
+```bash
+docker run -d --name videx-server \
+  -p 5001:5001 \
+  kangrongme/videx-server:0.2.0
+```
+
+### Step 2: Build VIDEX schema via videx-sync
+
+```bash
+docker run --rm --name videx-sync \
+  kangrongme/videx-server:0.2.0 sync \
+  --target 203.0.113.42:15508:tpch_tiny:videx:password \
+  --videx  203.0.113.42:15508:videx_tpch_tiny:videx:password \
+  --videx_server 203.0.113.42:5001
+```
+
+### Step 3: EXPLAIN on the original schema
+
+Run `EXPLAIN` on your original tables:
+
+```sql
+USE tpch_tiny;
+SET SESSION use_stat_tables = NEVER;
+EXPLAIN SELECT s_name, count(*) AS numwait FROM supplier, lineitem l1, orders, nation WHERE s_suppkey = l1.l_suppkey AND o_orderkey = l1.l_orderkey AND o_orderstatus = 'F' AND l1.l_receiptdate > l1.l_commitdate AND EXISTS (SELECT * FROM lineitem l2 WHERE l2.l_orderkey = l1.l_orderkey AND l2.l_suppkey <> l1.l_suppkey) AND NOT EXISTS (SELECT * FROM lineitem l3 WHERE l3.l_orderkey = l1.l_orderkey AND l3.l_suppkey <> l1.l_suppkey AND l3.l_receiptdate > l3.l_commitdate) AND s_nationkey = n_nationkey AND n_name = 'IRAQ' GROUP BY s_name ORDER BY numwait DESC, s_name; 
+
+```
+
+> Note: Collecting histograms may change MariaDB’s cardinality estimates (i.e., histogram-based estimates rather than InnoDB index statistics). Since VIDEX aims to simulate InnoDB index engine behavior, users can set `SET SESSION use_stat_tables = NEVER;` to make `EXPLAIN` results more similar between InnoDB and the VIDEX engine.
+
+The `EXPLAIN` output for the original schema is:
+
+```
++----+--------------------+----------+--------+-------------------------------------------------------+--------------+---------+--------------------------------+-------+----------------------------------------------+
+| id | select_type        | table    | type   | possible_keys                                         | key          | key_len | ref                            | rows  | Extra                                        |
++----+--------------------+----------+--------+-------------------------------------------------------+--------------+---------+--------------------------------+-------+----------------------------------------------+
+| 1  | PRIMARY            | orders   | ALL    | PRIMARY                                               | <null>       | <null>  | <null>                         | 14944 | Using where; Using temporary; Using filesort |
+| 1  | PRIMARY            | l1       | ref    | LINEITEM_UK1,LINEITEM_FK1                             | LINEITEM_FK1 | 4       | tpch_tiny.orders.O_ORDERKEY    | 1     | Using where                                  |
+| 1  | PRIMARY            | supplier | eq_ref | PRIMARY,SUPPLIER_FK1,idx_S_NATIONKEY_S_SUPPKEY_S_NAME | PRIMARY      | 4       | tpch_tiny.l1.L_SUPPKEY         | 1     |                                              |
+| 1  | PRIMARY            | nation   | eq_ref | PRIMARY                                               | PRIMARY      | 4       | tpch_tiny.supplier.S_NATIONKEY | 1     | Using where                                  |
+| 1  | PRIMARY            | l2       | ref    | LINEITEM_UK1,LINEITEM_FK1                             | LINEITEM_FK1 | 4       | tpch_tiny.orders.O_ORDERKEY    | 1     | Using where; FirstMatch(nation)              |
+| 3  | DEPENDENT SUBQUERY | l3       | ref    | LINEITEM_UK1,LINEITEM_FK1                             | LINEITEM_UK1 | 4       | tpch_tiny.l1.L_ORDERKEY        | 1     | Using where                                  |
++----+--------------------+----------+--------+-------------------------------------------------------+--------------+---------+--------------------------------+-------+----------------------------------------------+
+```
+
+### Step 4: EXPLAIN on the VIDEX schema
+
+Run `EXPLAIN` on the VIDEX schema (tables are `ENGINE=VIDEX`):
+
+```sql
+USE videx_tpch_tiny;
+SET SESSION videx_server_ip = '203.0.113.42:5001';
+EXPLAIN SELECT s_name, count(*) AS numwait FROM supplier, lineitem l1, orders, nation WHERE s_suppkey = l1.l_suppkey AND o_orderkey = l1.l_orderkey AND o_orderstatus = 'F' AND l1.l_receiptdate > l1.l_commitdate AND EXISTS (SELECT * FROM lineitem l2 WHERE l2.l_orderkey = l1.l_orderkey AND l2.l_suppkey <> l1.l_suppkey) AND NOT EXISTS (SELECT * FROM lineitem l3 WHERE l3.l_orderkey = l1.l_orderkey AND l3.l_suppkey <> l1.l_suppkey AND l3.l_receiptdate > l3.l_commitdate) AND s_nationkey = n_nationkey AND n_name = 'IRAQ' GROUP BY s_name ORDER BY numwait DESC, s_name; 
+```
+
+The `EXPLAIN` output for the VIDEX schema is:
+
+```
++----+--------------------+----------+--------+-------------------------------------------------------+--------------+---------+--------------------------------------+-------+----------------------------------------------+
+| id | select_type        | table    | type   | possible_keys                                         | key          | key_len | ref                                  | rows  | Extra                                        |
++----+--------------------+----------+--------+-------------------------------------------------------+--------------+---------+--------------------------------------+-------+----------------------------------------------+
+| 1  | PRIMARY            | orders   | ALL    | PRIMARY                                               | <null>       | <null>  | <null>                               | 14883 | Using where; Using temporary; Using filesort |
+| 1  | PRIMARY            | l1       | ref    | LINEITEM_UK1,LINEITEM_FK1                             | LINEITEM_FK1 | 4       | videx_tpch_tiny.orders.O_ORDERKEY    | 1     | Using where                                  |
+| 1  | PRIMARY            | supplier | eq_ref | PRIMARY,SUPPLIER_FK1,idx_S_NATIONKEY_S_SUPPKEY_S_NAME | PRIMARY      | 4       | videx_tpch_tiny.l1.L_SUPPKEY         | 1     |                                              |
+| 1  | PRIMARY            | nation   | eq_ref | PRIMARY                                               | PRIMARY      | 4       | videx_tpch_tiny.supplier.S_NATIONKEY | 1     | Using where                                  |
+| 1  | PRIMARY            | l2       | ref    | LINEITEM_UK1,LINEITEM_FK1                             | LINEITEM_FK1 | 4       | videx_tpch_tiny.orders.O_ORDERKEY    | 1     | Using where; FirstMatch(nation)              |
+| 3  | DEPENDENT SUBQUERY | l3       | ref    | LINEITEM_UK1,LINEITEM_FK1                             | LINEITEM_UK1 | 4       | videx_tpch_tiny.l1.L_ORDERKEY        | 1     | Using where                                  |
++----+--------------------+----------+--------+-------------------------------------------------------+--------------+---------+--------------------------------------+-------+----------------------------------------------+
+```
+
+Compare the output between Step 3 and Step 4.
+
+---
+
+## 9. Notes and best practices
+
+1) `videx-sync` can be time-consuming on large schemas, because it needs to collect metadata/statistics.
+   The metadata collection method is extensible; the VIDEX source repository also discusses lighter-weight sampling approaches.
+
+2) Networking matters. Since VIDEX-Server is often in a container, `localhost/127.0.0.1` may not refer to what you expect.
+    The routable IP is recommended for reachability, as it ensures that both MariaDB-VIDEX and the container can reach it.

--- a/src/sub_platforms/sql_opt/videx/scripts/videx_build_env.py
+++ b/src/sub_platforms/sql_opt/videx/scripts/videx_build_env.py
@@ -36,9 +36,12 @@ def get_usage_message(args, videx_ip, videx_port, videx_db, videx_user, videx_pw
                 "\n"
                 f"-- Connect VIDEX-MySQL: mysql -h{videx_ip} -P{videx_port} -u{videx_user} -p{videx_pwd} -D{videx_db}\n"
                 f"USE {videx_db};\n"
-                f"SET @VIDEX_SERVER='{videx_server_ip_port}'; -- For MySQL \n"
+                f"-------- For MySQL --------\n"
+                f"SET @VIDEX_SERVER='{videx_server_ip_port}';\n"
                 f"SET @VIDEX_OPTIONS='{videx_options}';\n"
-                f"SET SESSION VIDEX_SERVER_IP='127.0.0.1:5001'; -- For MariaDB \n"
+                f"-------- For MariaDB --------\n"
+                f"SET SESSION VIDEX_SERVER_IP='{videx_server_ip_port}';\n"
+                f"SET SESSION VIDEX_OPTIONS='{videx_options}';\n"
                 f"-- EXPLAIN YOUR_SQL;\n"
                 f"{mysql57_msg}")
     else:
@@ -48,8 +51,10 @@ def get_usage_message(args, videx_ip, videx_port, videx_db, videx_user, videx_pw
                 "\n"
                 f"-- Connect VIDEX-MySQL: mysql -h{videx_ip} -P{videx_port} -u{videx_user} -p{videx_pwd} -D{videx_db}\n"
                 f"USE {videx_db};\n"
-                f"SET @VIDEX_SERVER='{videx_server_ip_port}'; -- For MySQL \n"
-                f"SET SESSION VIDEX_SERVER_IP='127.0.0.1:5001'; -- For MariaDB \n"
+                f"-------- For MySQL --------\n"
+                f"SET @VIDEX_SERVER='{videx_server_ip_port}';\n"
+                f"-------- For MariaDB --------\n"
+                f"SET SESSION VIDEX_SERVER_IP='{videx_server_ip_port}';\n"
                 f"-- EXPLAIN YOUR_SQL;\n"
                 f"{mysql57_msg}")
 


### PR DESCRIPTION
## Pull Request Summary

This PR introduces a combined `videx-server` Docker image that can run either the VIDEX server or the `videx-sync` workflow from the same image, removing the need to prepare a separate Python environment for `videx_build_env`/`videx-sync`. It also adds Docker usage documentation in `doc/VIDEX_SERVER_DOCKER.md`.

## Related Issues

Related: MDEV-38422

## Detailed Description

**What problem does this PR solve?**
Previously, the Dockerfile and documentation did not provide an easy “one-image” path for the full VIDEX flow. In practice, users had to run the server and then run `videx-sync` (`videx_build_env`) separately, which typically required setting up a dedicated Python environment outside the container. 

This PR makes an end-to-end experience (start server + sync metadata) using several docker commands.

**How does the solution work?**
- A new consolidated image `kangrongme/videx-server:0.2.0` is provided (and pushed) which supports two entrypoint modes:
  - `server` (default): starts the VIDEX server
  - `sync`: runs the one-shot `videx-sync` / `videx_build_env` workflow
- The documentation `doc/VIDEX_SERVER_DOCKER.md` explains:
    - how to start the server container
    - how to run sync using the same image
    - recommended networking guidance (use a routable IP rather than `localhost`) for a smoother workflow
- Added a draft documentation to explain what VIDEX is and how to use VIDEX (to be submitted to MariaDB-docs): `doc/videx-storage-engine.md`.

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to VIDEX! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Core]</code>: Changes to core engine functionality</li>
    <li><code>[Opt]</code>: Changes to VIDEX-Optimizer-Plugin</li>
    <li><code>[Stats]</code>: Changes to VIDEX-Statistic-Server</li>
    <li><code>[Algo]</code>: Implementation of new algorithms for NDV, cardinality estimation, etc.</li>
    <li><code>[Pipe]</code>: Enhancements to the pipeline (e.g., data collection, environment setup)</li>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[Test]</code>: Adding or updating tests</li>
    <li><code>[Perf]</code>: Performance improvements</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use the most specific prefix or multiple prefixes in order of importance (e.g., [Algorithm][Stats]).</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Changes have been tested on both Plugin-Mode and Standalone-Mode (if applicable)</li>
    <li>[ ] Statistical accuracy has been verified (for algorithm or optimizer changes)</li>
    <li>[ ] No regression in query plan accuracy compared to InnoDB (if applicable)</li>
    <li>[ ] Performance benchmarks conducted (for performance-sensitive changes)</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>
