### PR TITLE
fix(histogram): Auto-fix non-monotonic buckets for equi-height

### DIFF
--- a/src/sub_platforms/sql_opt/videx/videx_histogram.py
+++ b/src/sub_platforms/sql_opt/videx/videx_histogram.py
@@ -269,8 +269,10 @@ class HistogramStats(BaseModel, PydanticDataClassJsonMixin):
                 monotonically_increasing = False
                 break
         if not monotonically_increasing:
-            # Currently, we can only handle the non-monotonically increasing issue for the singleton type.
-            if self.histogram_type == 'singleton':
+            # Handle non-monotonically increasing buckets by sorting them.
+            # This can happen due to collation differences between database and Python.
+            # For example, database may use case-insensitive collation while Python uses binary comparison.
+            if self.histogram_type in ('singleton', 'equi-height'):
                 # 1. Sort the buckets based on their min_value.
                 # This puts the buckets in the correct monotonic order.
                 self.buckets.sort(key=lambda b_: b_.min_value)


### PR DESCRIPTION
## Pull Request Summary

When histogram buckets are validated in Python with binary string comparison, they can be reported as non-monotonic, causing `videx_build_env` to raise `Buckets must have monotonically increasing` when building equi-height histograms for string columns.

- **Cause:** DB uses case-insensitive (or other) collation, so bucket order can differ from Python’s string comparison.
- **Changes:** Extend the existing auto-fix (sort by `min_value`, recompute `cum_freq`) from `singleton` to **equi-height** as well.

## Related Issues

#76 #74 

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to VIDEX! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Core]</code>: Changes to core engine functionality</li>
    <li><code>[Opt]</code>: Changes to VIDEX-Optimizer-Plugin</li>
    <li><code>[Stats]</code>: Changes to VIDEX-Statistic-Server</li>
    <li><code>[Algo]</code>: Implementation of new algorithms for NDV, cardinality estimation, etc.</li>
    <li><code>[Pipe]</code>: Enhancements to the pipeline (e.g., data collection, environment setup)</li>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[Test]</code>: Adding or updating tests</li>
    <li><code>[Perf]</code>: Performance improvements</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use the most specific prefix or multiple prefixes in order of importance (e.g., [Algorithm][Stats]).</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Changes have been tested on both Plugin-Mode and Standalone-Mode (if applicable)</li>
    <li>[ ] Statistical accuracy has been verified (for algorithm or optimizer changes)</li>
    <li>[ ] No regression in query plan accuracy compared to InnoDB (if applicable)</li>
    <li>[ ] Performance benchmarks conducted (for performance-sensitive changes)</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>
