### PR TITLE
fix(ha_videx): free curl resources to prevent memory leak

### DIFF
--- a/src/mariadb/videx/ha_videx.cc
+++ b/src/mariadb/videx/ha_videx.cc
@@ -238,6 +238,11 @@ int ask_from_videx_http(VidexJsonItem &request, VidexStringMap &res_json,
     curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
     res_code= curl_easy_perform(curl);
+
+    // Free curl resources to avoid memory leak
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+
     if (res_code != CURLE_OK)
     {
       sql_print_warning(

--- a/src/mysql/videx/ha_videx.cc
+++ b/src/mysql/videx/ha_videx.cc
@@ -108,6 +108,11 @@ int ask_from_videx_http(VidexJsonItem &request, VidexStringMap &res_json, THD* t
 
       trace_http.add_utf8("request", request_str.c_str());
       res_code = curl_easy_perform(curl);
+
+      // Free curl resources to avoid memory leak
+      curl_slist_free_all(headers);
+      curl_easy_cleanup(curl);
+
       if (res_code != CURLE_OK) {
         trace_http.add("success", false)
             .add_utf8("reason", "res_code != CURLE_OK")


### PR DESCRIPTION
## Pull Request Summary

Fix memory leak by properly releasing curl handle and headers after HTTP requests in ha_videx.cc.

## Detailed Description

- **Problem:** `curl_easy_cleanup()` and `curl_slist_free_all()` were not called after `curl_easy_perform()`, causing memory leak on each HTTP request to videx_server.
- **Solution:** Added cleanup calls for both MySQL and MariaDB versions of ha_videx.cc.