### PR TITLE
[Stats][Bug] Handle string NULL histogram boundaries

### DIFF
--- a/src/sub_platforms/sql_opt/videx/videx_histogram.py
+++ b/src/sub_platforms/sql_opt/videx/videx_histogram.py
@@ -302,7 +302,7 @@ class HistogramStats(BaseModel, PydanticDataClassJsonMixin):
         # Handle the universal case where the query boundary is NULL.
         # The position of NULLs is conceptually at the beginning of the sorted data.
         # This logic is independent of whether the histogram for non-null values exists.
-        if value is None:
+        if value is None or value == NULL_STR:
             if side == BTreeKeySide.left:
                 # Cumulative records *before* all NULLs is 0.
                 return 0

--- a/test/videx/test_records_in_range.py
+++ b/test/videx/test_records_in_range.py
@@ -134,6 +134,13 @@ class TestHist_find_first_key_pos(unittest.TestCase):
         print(function3)  # 输出 HaRKeyFunction.HA_READ_KEY_EXACT
         self.assertEqual(function3, BTreeKeyOp.EQ)
 
+    def test_string_null_boundary(self):
+        self.int_histogram.null_values = 0.2
+
+        for value in (None, "NULL"):
+            self.assertEqual(self.int_histogram.find_nearest_key_pos(value, BTreeKeySide.left), 0)
+            self.assertEqual(self.int_histogram.find_nearest_key_pos(value, BTreeKeySide.right), 0.2)
+
     def test_gt_operator(self):
         """
         EXPLAIN select I_PRICE from ITEM where I_PRICE = 12


### PR DESCRIPTION
## Pull Request Summary

Treat the request protocol's `"NULL"` sentinel as a NULL histogram boundary before any bucket comparison. This prevents nullable integer and string range requests from converting the sentinel to `None` and then raising `TypeError`.

## Related Issues

Resolves: #92

## Detailed Description

`HistogramStats.find_nearest_key_pos()` already has the required left/right behavior for Python `None`, but the request fixtures carry the same boundary as the string `"NULL"`. The previous check missed that representation and `convert_str_by_type()` converted it only after the NULL branch.

This change extends the existing NULL branch to the shared `NULL_STR` constant. It deliberately leaves the remaining conversion order unchanged, including the existing empty-histogram behavior. A direct regression test verifies that Python `None` and `"NULL"` produce the same left and right positions.

No dependencies, public APIs, or configuration are changed.

## Validation

Python 3.9.13 on Windows 10 Pro N 22H2:

```text
python -m pytest -q -p no:cacheprovider test/videx/test_records_in_range.py::TestHist_find_first_key_pos::test_string_null_boundary test/videx/test_records_in_range_nullable.py test/videx/test_rec_in_ranges_singleton.py::Test_ask_rec_in_ranges::test_ask_rec_in_ranges_job_072_20a
5 passed, 4 warnings

python -m pytest -q -p no:cacheprovider test/videx
63 passed, 9 warnings
```

The warnings are existing dependency deprecations, collection warnings for `TestHandler`, and deprecated `assertAlmostEquals` calls.

## Submission Checklist

- [x] PR title includes appropriate prefixes
- [x] New and existing Python tests pass successfully
- [x] Code follows the existing project style
- [x] No documentation change is required for this internal correctness fix
- [ ] Plugin-mode integration was not run because the MySQL/MariaDB source trees and Linux build toolchain are not available in this Windows environment; the repository's serialized request fixtures cover the failing statistics-server path