### PR TITLE
[Algo][Bug] Fix independent multi-column NDV aggregation

### DIFF
--- a/src/sub_platforms/sql_opt/histogram/ndv_estimator.py
+++ b/src/sub_platforms/sql_opt/histogram/ndv_estimator.py
@@ -732,12 +732,10 @@ class NDVEstimator:
                 logging.info(f"NDV estimation failed for column {col} with method {method}: {e}")
                 individual_ndvs.append(1.0)
         
-        # Independent assumption synthesis: rows / product(rows / ndv_i)
+        # Independent assumption synthesis: product of individual NDVs, capped by table rows
         rows = float(self.original_num)
         from math import prod
-        rec_per_keys = [max(1.0, rows / x) for x in individual_ndvs]
-        combined_rpk = min(rows, prod(rec_per_keys))
-        ndv_multi = max(1.0, min(rows, rows / combined_rpk))
+        ndv_multi = max(1.0, min(rows, prod(individual_ndvs)))
         
         logging.info(f"Independent assumption: {target_columns} -> {individual_ndvs} -> {ndv_multi}")
         return ndv_multi

--- a/test/videx/test_ndv_estimator.py
+++ b/test/videx/test_ndv_estimator.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""
+Copyright (c) 2024 Bytedance Ltd. and/or its affiliates
+SPDX-License-Identifier: MIT
+"""
+import unittest
+
+from pandas import DataFrame
+
+from sub_platforms.sql_opt.histogram.ndv_estimator import NDVEstimator
+
+
+class TestNDVEstimator(unittest.TestCase):
+    def test_multi_column_independent_estimate(self):
+        estimator = NDVEstimator(original_num=1000)
+        estimator.estimator = lambda *args, **kwargs: 10
+        sampled_data = DataFrame({"a": range(10), "b": range(10)})
+
+        actual = estimator._estimate_multi_columns_independent(
+            sampled_data, ["a", "b"], "scale"
+        )
+
+        self.assertEqual(actual, 100)
+
+    def test_multi_column_independent_estimate_is_capped_by_rows(self):
+        estimator = NDVEstimator(original_num=1000)
+        estimator.estimator = lambda *args, **kwargs: 100
+        sampled_data = DataFrame({"a": range(10), "b": range(10)})
+
+        actual = estimator._estimate_multi_columns_independent(
+            sampled_data, ["a", "b"], "scale"
+        )
+
+        self.assertEqual(actual, 1000)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Pull Request Summary

Correct independent multi-column NDV aggregation by multiplying the individual column estimates and capping the result at the table row count. Add deterministic regression tests for both the ordinary product and the row-count cap.

## Related Issues

Resolves: #93

## Detailed Description

`_estimate_multi_columns_independent()` previously multiplied per-column records-per-key values (`rows / ndv_i`) and then divided rows by that product. For a 1,000-row table with two per-column NDVs of 10, that formula returns 1 instead of the independence estimate 100.

The corrected calculation is `min(rows, product(individual_ndvs))`, with the existing lower bound of 1. This matches the independent-assumption formula already used by `VidexStrategy.calc_ndv_mulcol_by_independent_assumption()`.

The regression tests replace only the single-column estimator step with deterministic values, so they isolate aggregation behavior without relying on model weights or sampling variability.

No dependencies, public APIs, or configuration are changed.

## Validation

Python 3.9.13 on Windows 10 Pro N 22H2:

```text
python -m pytest -q -p no:cacheprovider test/videx/test_ndv_estimator.py
2 passed, 2 warnings

python -m pytest -q -p no:cacheprovider test/videx -k "not test_ask_rec_in_ranges_job_072_20a and not test_eq_NULL and not test_gt_NULL_and_lt_empty_str and not test_neq_NULL"
60 passed, 4 deselected, 9 warnings

python -m pytest -q -p no:cacheprovider test/videx
60 passed, 4 failed, 9 warnings
```

The four full-suite failures reproduce the pre-existing string-NULL histogram defect in #92 and are fixed independently by #94; this PR intentionally does not mix that unrelated change. The warnings are existing dependency deprecations, collection warnings for `TestHandler`, and deprecated `assertAlmostEquals` calls.

## Submission Checklist

- [x] PR title includes appropriate prefixes
- [x] New multi-column NDV regression tests pass
- [x] All tests unrelated to the separately tracked #92 defect pass
- [x] Statistical aggregation was verified with deterministic product and cap cases
- [x] Code follows the existing project style
- [x] No documentation change is required for this internal algorithm correction
- [ ] The unfiltered suite is not fully green because of the four pre-existing #92 failures described above
- [ ] Plugin-mode/query-plan integration was not run because database source trees, workloads, and a Linux build environment are not available locally